### PR TITLE
Keep reference to SettingsButton and OptionsButton

### DIFF
--- a/ModLoader/ModLoader.csproj
+++ b/ModLoader/ModLoader.csproj
@@ -11,8 +11,7 @@
     <AssemblyName>SpaarModLoader</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -25,7 +24,6 @@
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,7 +35,6 @@
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Build and Install|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -48,7 +45,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugDeveloper|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -60,7 +56,6 @@
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseDeveloper|AnyCPU'">
     <OutputPath>bin\ReleaseDeveloper\</OutputPath>
@@ -72,7 +67,6 @@
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/ModLoader/ModLoader.csproj
+++ b/ModLoader/ModLoader.csproj
@@ -11,7 +11,8 @@
     <AssemblyName>SpaarModLoader</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,6 +25,7 @@
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,6 +37,7 @@
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Build and Install|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -45,6 +48,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugDeveloper|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -56,6 +60,7 @@
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseDeveloper|AnyCPU'">
     <OutputPath>bin\ReleaseDeveloper\</OutputPath>
@@ -67,6 +72,7 @@
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/ModLoader/OptionsMenu.cs
+++ b/ModLoader/OptionsMenu.cs
@@ -1,140 +1,225 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using spaar.ModLoader.Internal;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace spaar.ModLoader
 {
-  /// <summary>
-  /// Callback delegate for an option toggle.
-  /// </summary>
-  /// <param name="active">Whether the toggle is active</param>
-  public delegate void OptionsToggle(bool active);
-
-  /// <summary>
-  /// OptionsMenu contains methods for adding an option (toggle button) to the
-  /// options menu in the main menu of Besiege.
-  /// </summary>
-  public class OptionsMenu : SingleInstance<OptionsMenu>
-  {
-    public override string Name { get; } = "spaar's Mod Loader: Options Utility";
-
-    private struct OptionsButton
-    {
-      public string text;
-      public OptionsToggle cb;
-      public bool defaultValue;
-      public int fontSize;
-    }
-
-    private static int numRegistered = 0;
-
-    private static List<OptionsButton> toAdd = new List<OptionsButton>();
+    /// <summary>
+    ///     Callback delegate for an option toggle.
+    /// </summary>
+    /// <param name="active">Whether the toggle is active</param>
+    public delegate void OptionsToggle(bool active);
 
     /// <summary>
-    /// Registers a new toggle button. It will be placed below all others that
-    /// are currently registered.
     /// </summary>
-    /// <param name="text">The text to display on the button</param>
-    /// <param name="cb">Callback to call when the button is clicked</param>
-    /// <param name="defaultValue">Starting state of the toggle</param>
-    /// <param name="fontSize">Font size of the text on the button</param>
-    public static void RegisterOptionsToggle(string text, OptionsToggle cb,
-      bool defaultValue = false, int fontSize = 0)
+    public class OptionsButton
     {
-      var button = new OptionsButton()
-      {
-        text = text,
-        cb = cb,
-        defaultValue = defaultValue,
-        fontSize = fontSize
-      };
-      toAdd.Add(button);
+        private bool _created;
+        private int _fontSize;
 
-      if (SceneManager.GetActiveScene().buildIndex == 1) // Main Menu
-        RegisterOptionsToggleInternal(button);
-    }
+        private string _text;
+        private bool _value;
 
-    private void Start()
-    {
-      Internal.ModLoader.MakeModule(this);
+        internal Action OnDestroy;
+        internal Action<int> OnFontSizeChange;
+        internal Action<string> OnTextChange;
 
-      SceneManager.sceneLoaded += OnSceneLoaded;
-    }
+        /// <summary>
+        ///     Called on Value change.
+        /// </summary>
+        public OptionsToggle OnToggle;
 
-    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
-    {
-      if (SceneManager.GetActiveScene().buildIndex == 1) // Main Menu
-      {
-        numRegistered = 0;
-        foreach (var button in toAdd)
+        public string Text
         {
-          RegisterOptionsToggleInternal(button);
+            get { return _text; }
+            set
+            {
+                OnTextChange?.Invoke(value);
+                _text = value;
+            }
         }
-      }
+
+        public int FontSize
+        {
+            get { return _fontSize; }
+            set
+            {
+                OnFontSizeChange?.Invoke(value);
+                _fontSize = value;
+            }
+        }
+
+        public bool Value
+        {
+            get { return _value; }
+            set
+            {
+                OnToggle?.Invoke(value);
+                _value = value;
+            }
+        }
+
+        public void Create()
+        {
+            if (_created) return;
+            OptionsMenu.RegisterOptionsToggle(this);
+            _created = true;
+        }
+
+        public void Destroy()
+        {
+            OnDestroy?.Invoke();
+            OnToggle = null;
+            OnDestroy = null;
+            OnFontSizeChange = null;
+            OnTextChange = null;
+            _created = false;
+        }
     }
 
-    private static Transform optionsList;
-    private static Transform windowedText;
-    private static Transform windowedTickBox;
-
-    private static void RegisterOptionsToggleInternal(OptionsButton button)
+    /// <summary>
+    ///     OptionsMenu contains methods for adding an option (toggle button) to the
+    ///     options menu in the main menu of Besiege.
+    /// </summary>
+    public class OptionsMenu : SingleInstance<OptionsMenu>
     {
-      if (optionsList == null)
-      {
-        GameObject.Find("O P T I O N S")
-          .GetComponent<EnableObjOnClick>().OnMouseUp();
-        optionsList = GameObject.Find("OPTIONS LIST").transform;
-      }
+        private static int _numRegistered;
 
-      if (numRegistered == 0)
-      {
-        // Move Windowed setting up to make room
-        windowedText = optionsList.FindChild("WINDOWED");
-        windowedText.Translate(0f, 1.3f, 0f);
-        windowedTickBox = optionsList.FindChild("WINDOWED TICK BOX");
-        windowedTickBox.Translate(0f, 1.3f, 0f);
-      }
+        private static readonly List<OptionsButton> ToAdd = new List<OptionsButton>();
 
-      var textPos = windowedText.position
-        + Vector3.down * 0.45f * (numRegistered + 1);
-      var textScale = windowedText.localScale;
-      var boxPos = windowedTickBox.position
-        + Vector3.down * 0.45f * (numRegistered + 1);
-      var boxScale = windowedTickBox.localScale;
+        private static Transform _optionsList;
+        private static Transform _windowedText;
+        private static Transform _windowedTickBox;
+        public override string Name { get; } = "spaar's Mod Loader: Options Utility";
 
-      var newText = (Transform)Instantiate(windowedText, textPos,
-        Quaternion.identity);
-      var newBox = (Transform)Instantiate(windowedTickBox, boxPos,
-        Quaternion.identity);
+        /// <summary>
+        ///     Registers a new toggle button. It will be placed below all others that
+        ///     are currently registered.
+        /// </summary>
+        /// <param name="text">The text to display on the button</param>
+        /// <param name="cb">Callback to call when the button is clicked</param>
+        /// <param name="defaultValue">Starting state of the toggle</param>
+        /// <param name="fontSize">Font size of the text on the button</param>
+        [Obsolete(
+            "RegisterOptionsButton is deprecated. Please initialize OptionsButton class instead and call it's Create method."
+        )]
+        public static void RegisterOptionsToggle(string text, OptionsToggle cb,
+            bool defaultValue = false, int fontSize = 0)
+        {
+            var button = new OptionsButton
+            {
+                Text = text,
+                OnToggle = cb,
+                Value = defaultValue,
+                FontSize = fontSize
+            };
+            ToAdd.Add(button);
 
-      newText.parent = optionsList;
-      newBox.parent = optionsList;
+            if (SceneManager.GetActiveScene().buildIndex == 1) // Main Menu
+                RegisterOptionsToggleInternal(button);
+        }
 
-      newText.name = button.text + " (Modded)";
-      newBox.name = button.text + "TickBox (Modded)";
+        internal static void RegisterOptionsToggle(OptionsButton button)
+        {
+            ToAdd.Add(button);
 
-      newText.localScale = textScale;
-      newBox.localScale = boxScale;
+            if (SceneManager.GetActiveScene().buildIndex == 1) // Main Menu
+                RegisterOptionsToggleInternal(button);
+        }
 
-      newText.GetComponent<TextMesh>().text = button.text;
-      if (button.fontSize != 0)
-        newText.GetComponent<TextMesh>().fontSize = button.fontSize;
+        private void Start()
+        {
+            Internal.ModLoader.MakeModule(this);
 
-      var fullscreenController = newBox.GetComponent<FullScreenController>();
-      var optionsComponent = newBox.gameObject.AddComponent<OptionsComponent>();
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
 
-      optionsComponent.darkMaterial = fullscreenController.darkMaterial;
-      optionsComponent.redMaterial = fullscreenController.redMaterial;
-      Destroy(fullscreenController);
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (SceneManager.GetActiveScene().buildIndex == 1) // Main Menu
+            {
+                _numRegistered = 0;
+                foreach (var button in ToAdd)
+                    RegisterOptionsToggleInternal(button);
+            }
+        }
 
-      optionsComponent.SetCallback(button.cb);
-      optionsComponent.SetOn(button.defaultValue);
+        private static void RegisterOptionsToggleInternal(OptionsButton button)
+        {
+            if (_optionsList == null)
+            {
+                GameObject.Find("O P T I O N S")
+                    .GetComponent<EnableObjOnClick>().OnMouseUp();
+                _optionsList = GameObject.Find("OPTIONS LIST").transform;
+            }
 
-      numRegistered++;
+            if (_numRegistered == 0)
+            {
+                // Move Windowed setting up to make room
+                _windowedText = _optionsList.FindChild("WINDOWED");
+                _windowedText.Translate(0f, 1.3f, 0f);
+                _windowedTickBox = _optionsList.FindChild("WINDOWED TICK BOX");
+                _windowedTickBox.Translate(0f, 1.3f, 0f);
+            }
 
-      optionsList.FindChild("QUIT WINDOW ICON")
-        .GetComponent<DisableObjOnClick>().OnMouseUp();
+            var textPos = _windowedText.position
+                          + Vector3.down * 0.45f * (_numRegistered + 1);
+            var textScale = _windowedText.localScale;
+            var boxPos = _windowedTickBox.position
+                         + Vector3.down * 0.45f * (_numRegistered + 1);
+            var boxScale = _windowedTickBox.localScale;
+
+            var newText = (Transform) Instantiate(_windowedText, textPos,
+                Quaternion.identity);
+            var newBox = (Transform) Instantiate(_windowedTickBox, boxPos,
+                Quaternion.identity);
+
+            newText.parent = _optionsList;
+            newBox.parent = _optionsList;
+
+            newText.name = button.Text + " (Modded)";
+            newBox.name = button.Text + "TickBox (Modded)";
+
+            newText.localScale = textScale;
+            newBox.localScale = boxScale;
+
+            newText.GetComponent<TextMesh>().text = button.Text;
+            if (button.FontSize != 0)
+                newText.GetComponent<TextMesh>().fontSize = button.FontSize;
+
+            var fullscreenController = newBox.GetComponent<FullScreenController>();
+            var optionsComponent = newBox.gameObject.AddComponent<OptionsComponent>();
+
+            optionsComponent.darkMaterial = fullscreenController.darkMaterial;
+            optionsComponent.redMaterial = fullscreenController.redMaterial;
+            Destroy(fullscreenController);
+
+            optionsComponent.SetCallback(button.OnToggle);
+            optionsComponent.SetOn(button.Value);
+
+            // Change material on button OnToggle
+            button.OnToggle += value => optionsComponent.SetOn(value);
+
+            // Change textMesh on Text property change
+            button.OnTextChange += value => newText.GetComponent<TextMesh>().text = value;
+
+            // Change font size on FontSize property change
+            button.OnFontSizeChange += value => newText.GetComponent<TextMesh>().fontSize = value;
+
+            // Set button OnDestroy method
+            button.OnDestroy += () =>
+            {
+                Destroy(newText.gameObject);
+                Destroy(newBox.gameObject);
+                _numRegistered--;
+            };
+
+            _numRegistered++;
+
+            _optionsList.FindChild("QUIT WINDOW ICON")
+                .GetComponent<DisableObjOnClick>().OnMouseUp();
+        }
     }
-  }
 }

--- a/ModLoader/SettingsMenu.cs
+++ b/ModLoader/SettingsMenu.cs
@@ -7,16 +7,30 @@ using UnityEngine.SceneManagement;
 namespace spaar.ModLoader
 {
     /// <summary>
-    /// Callback delegate for a toggle setting.
+    ///     Callback delegate for a toggle setting.
     /// </summary>
     /// <param name="active">Whether the toggle is active</param>
     public delegate void SettingsToggle(bool active);
 
     /// <summary>
-    ///  
     /// </summary>
     public class SettingsButton
     {
+        private bool _created;
+        private int _fontSize;
+
+        private string _text;
+        private bool _value;
+
+        internal Action OnDestroy;
+        internal Action<int> OnFontSizeChange;
+        internal Action<string> OnTextChange;
+
+        /// <summary>
+        ///     Called on Value change.
+        /// </summary>
+        public SettingsToggle OnToggle;
+
         public string Text
         {
             get { return _text; }
@@ -36,6 +50,7 @@ namespace spaar.ModLoader
                 _fontSize = value;
             }
         }
+
         public bool Value
         {
             get { return _value; }
@@ -45,20 +60,6 @@ namespace spaar.ModLoader
                 _value = value;
             }
         }
-
-        private string _text;
-        private int _fontSize;
-        private bool _value;
-        private bool _created;
-
-        /// <summary>
-        /// Called on Value change.
-        /// </summary>
-        public SettingsToggle OnToggle;
-
-        internal Action OnDestroy;
-        internal Action<int> OnFontSizeChange;
-        internal Action<string> OnTextChange;
 
         public void Create()
         {
@@ -79,37 +80,41 @@ namespace spaar.ModLoader
     }
 
     /// <summary>
-    /// SettingsMenu contains methods for adding a setting (toggle button) to the
-    /// settings drop-down of Besiege.
+    ///     SettingsMenu contains methods for adding a setting (toggle button) to the
+    ///     settings drop-down of Besiege.
     /// </summary>
     public class SettingsMenu : SingleInstance<SettingsMenu>
     {
-        public override string Name { get { return "spaar's Mod Loader: Settings Utility"; } }
+        private static int _numRegistered;
 
-        private static int numRegistered = 0;
+        private static readonly List<SettingsButton> ToAdd = new List<SettingsButton>();
 
-        private static List<SettingsButton> toAdd = new List<SettingsButton>();
+        private static Transform _modSection;
+
+        public override string Name => "spaar's Mod Loader: Settings Utility";
 
         /// <summary>
-        /// Registers a new toggle button. It will be placed below all others
-        /// that are currently registered.
+        ///     Registers a new toggle button. It will be placed below all others
+        ///     that are currently registered.
         /// </summary>
         /// <param name="text">The text to display on the button</param>
         /// <param name="cb">Callback to call when the button is clicked</param>
         /// <param name="defaultValue">Starting state of the toggle</param>
         /// <param name="fontSize">Font size of the text on the button</param>
-        [Obsolete("RegisterSettingsButton is deprecated. Please initialize SettingsButton class instead and call it's Create method.")]
+        [Obsolete(
+            "RegisterSettingsButton is deprecated. Please initialize SettingsButton class instead and call it's Create method."
+        )]
         public static void RegisterSettingsButton(string text, SettingsToggle cb,
-          bool defaultValue = false, int fontSize = 0)
+            bool defaultValue = false, int fontSize = 0)
         {
-            var button = new SettingsButton()
+            var button = new SettingsButton
             {
                 Text = text,
                 OnToggle = cb,
                 Value = defaultValue,
                 FontSize = fontSize
             };
-            toAdd.Add(button);
+            ToAdd.Add(button);
 
             if (Game.AddPiece != null)
                 RegisterSettingsButtonInternal(button);
@@ -117,7 +122,7 @@ namespace spaar.ModLoader
 
         internal static void RegisterSettingsButton(SettingsButton button)
         {
-            toAdd.Add(button);
+            ToAdd.Add(button);
 
             if (Game.AddPiece != null)
                 RegisterSettingsButtonInternal(button);
@@ -134,24 +139,20 @@ namespace spaar.ModLoader
         {
             if (Game.AddPiece != null)
             {
-                numRegistered = 0;
-                foreach (var button in toAdd)
-                {
+                _numRegistered = 0;
+                foreach (var button in ToAdd)
                     RegisterSettingsButtonInternal(button);
-                }
             }
         }
-
-        private static Transform modSection;
 
         private static void RegisterSettingsButtonInternal(SettingsButton button)
         {
             var settingsObjects = GameObject.Find("Settings").transform
-              .FindChild("SettingsObjects");
+                .FindChild("SettingsObjects");
             var bottomDefaultSetting = settingsObjects.FindChild("GOD/INFINITE AMMO");
-            Vector3 SettingSize = new Vector3(0.748f, 0.375f);
+            var settingSize = new Vector3(0.748f, 0.375f);
 
-            if (modSection == null)
+            if (_modSection == null)
             {
                 // Create a MODS section
                 var settings = settingsObjects.FindChild("SETTINGS");
@@ -160,13 +161,12 @@ namespace spaar.ModLoader
                 modsPos.y = bottomDefaultSetting.position.y - 1.2f;
                 modsPos.z = 7.0f; // Prevent blocks GUI from being over the toggles
 
-                modSection = (Transform)Instantiate(settings, modsPos,
-                  settings.rotation);
-                modSection.parent = settingsObjects;
-                modSection.name = "MOD SETTINGS";
+                _modSection = (Transform) Instantiate(settings, modsPos,
+                    settings.rotation);
+                _modSection.parent = settingsObjects;
+                _modSection.name = "MOD SETTINGS";
 
-                foreach (Transform child in modSection)
-                {
+                foreach (Transform child in _modSection)
                     if (child.name == "GENERAL")
                     {
                         child.GetComponent<TextMesh>().text = "M O D S";
@@ -176,7 +176,6 @@ namespace spaar.ModLoader
                     {
                         Destroy(child.gameObject);
                     }
-                }
 
                 // Adjust background to include mods section title
                 var bg = settingsObjects.FindChild("BG");
@@ -197,25 +196,25 @@ namespace spaar.ModLoader
                 pos.z = 15.0f; // Put collider behind all settings items
                 scrollCollider.position = pos;
                 scrollCollider.gameObject.AddComponent<ScrollSettingsMenu>()
-                  .settingsObjects = settingsObjects;
+                    .settingsObjects = settingsObjects;
             }
             var settingPos = bottomDefaultSetting.position;
 
-            settingPos.x += (numRegistered % 2) * SettingSize.x;
-            settingPos.y -= 1.25f + (numRegistered / 2) * SettingSize.y;
+            settingPos.x += _numRegistered % 2 * settingSize.x;
+            settingPos.y -= 1.25f + _numRegistered / 2 * settingSize.y;
             settingPos.z = 7.0f; // Prevent blocks GUI from being over any toggles
 
             var fxaa = settingsObjects.FindChild("SETTINGS/FXAA");
 
-            var newSetting = (Transform)Instantiate(fxaa, settingPos, fxaa.rotation);
-            newSetting.parent = modSection;
+            var newSetting = (Transform) Instantiate(fxaa, settingPos, fxaa.rotation);
+            newSetting.parent = _modSection;
 
-            if (numRegistered % 2 == 0)
+            if (_numRegistered % 2 == 0)
             {
                 // Expand background to include new toggle
                 var background = settingsObjects.FindChild("BG");
                 var backgroundScale = background.localScale;
-                backgroundScale.y += SettingSize.y * 2;
+                backgroundScale.y += settingSize.y * 2;
                 background.localScale = backgroundScale;
 
                 // Expand the scrolling object to the same size
@@ -225,12 +224,10 @@ namespace spaar.ModLoader
 
                 // Check whether the new element row is outside of the screen
                 // and enable scrolling if it is
-                var lowestPoint = newSetting.position - SettingSize;
+                var lowestPoint = newSetting.position - settingSize;
                 var cam = GameObject.Find("HUD Cam").GetComponent<Camera>();
                 if (cam.WorldToViewportPoint(lowestPoint).y < 0.0f)
-                {
                     scrolling.GetComponent<ScrollSettingsMenu>().scrollingEnabled = true;
-                }
             }
 
             var newSettingButton = newSetting.FindChild("AA BUTTON");
@@ -243,7 +240,7 @@ namespace spaar.ModLoader
             textMesh.fontSize = button.FontSize;
 
             var settingsComponent
-              = newSettingButton.gameObject.AddComponent<SettingsComponent>();
+                = newSettingButton.gameObject.AddComponent<SettingsComponent>();
 
             var fxaaToggle = newSettingButton.gameObject.GetComponent<ToggleAA>();
             settingsComponent.darkMaterial = fxaaToggle.darkMaterial;
@@ -266,10 +263,10 @@ namespace spaar.ModLoader
             button.OnDestroy += () =>
             {
                 Destroy(newSetting.gameObject);
-                numRegistered--;
+                _numRegistered--;
             };
 
-            numRegistered++;
+            _numRegistered++;
         }
     }
 }

--- a/ModLoader/SettingsMenu.cs
+++ b/ModLoader/SettingsMenu.cs
@@ -5,187 +5,224 @@ using UnityEngine.SceneManagement;
 
 namespace spaar.ModLoader
 {
-  /// <summary>
-  /// Callback delegate for a toggle setting.
-  /// </summary>
-  /// <param name="active">Whether the toggle is active</param>
-  public delegate void SettingsToggle(bool active);
-
-  /// <summary>
-  /// SettingsMenu contains methods for adding a setting (toggle button) to the
-  /// settings drop-down of Besiege.
-  /// </summary>
-  public class SettingsMenu : SingleInstance<SettingsMenu>
-  {
-    public override string Name { get { return "spaar's Mod Loader: Settings Utility"; } }
-
-    private struct SettingsButton
-    {
-      public string text;
-      public SettingsToggle cb;
-      public bool defaultValue;
-      public int fontSize;
-    }
-
-    private static int numRegistered = 0;
-
-    private static List<SettingsButton> toAdd = new List<SettingsButton>();
+    /// <summary>
+    /// Callback delegate for a toggle setting.
+    /// </summary>
+    /// <param name="active">Whether the toggle is active</param>
+    public delegate void SettingsToggle(bool active);
 
     /// <summary>
-    /// Registers a new toggle button. It will be placed below all others
-    /// that are currently registered.
+    /// 
     /// </summary>
-    /// <param name="text">The text to display on the button</param>
-    /// <param name="cb">Callback to call when the button is clicked</param>
-    /// <param name="defaultValue">Starting state of the toggle</param>
-    /// <param name="fontSize">Font size of the text on the button</param>
-    public static void RegisterSettingsButton(string text, SettingsToggle cb,
-      bool defaultValue = false, int fontSize = 0)
+    public class SettingsButton
     {
-      var button = new SettingsButton()
-      {
-        text = text,
-        cb = cb,
-        defaultValue = defaultValue,
-        fontSize = fontSize
-      };
-      toAdd.Add(button);
+        public string Text;
 
-      if (Game.AddPiece != null)
-        RegisterSettingsButtonInternal(button);
-    }
-
-    private void Start()
-    {
-      Internal.ModLoader.MakeModule(this);
-
-      SceneManager.sceneLoaded += OnSceneLoaded;
-    }
-
-    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
-    {
-      if (Game.AddPiece != null)
-      {
-        numRegistered = 0;
-        foreach (var button in toAdd)
+        public bool Value
         {
-          RegisterSettingsButtonInternal(button);
-        }
-      }
-    }
-
-    private static Transform modSection;
-
-    private static void RegisterSettingsButtonInternal(SettingsButton button)
-    {
-      var settingsObjects = GameObject.Find("Settings").transform
-        .FindChild("SettingsObjects");
-      var bottomDefaultSetting = settingsObjects.FindChild("GOD/INFINITE AMMO");
-      Vector3 SettingSize = new Vector3(0.748f, 0.375f);
-
-      if (modSection == null)
-      {
-        // Create a MODS section
-        var settings = settingsObjects.FindChild("SETTINGS");
-
-        var modsPos = settings.position;
-        modsPos.y = bottomDefaultSetting.position.y - 1.2f;
-        modsPos.z = 7.0f; // Prevent blocks GUI from being over the toggles
-
-        modSection = (Transform)Instantiate(settings, modsPos,
-          settings.rotation);
-        modSection.parent = settingsObjects;
-        modSection.name = "MOD SETTINGS";
-
-        foreach (Transform child in modSection)
-        {
-          if (child.name == "GENERAL")
-          {
-            child.GetComponent<TextMesh>().text = "M O D S";
-            child.name = "Title";
-          }
-          else
-          {
-            Destroy(child.gameObject);
-          }
+            get { return _value; }
+            set
+            {
+                settingsComponent?.SetOn(value);
+                OnToggle?.Invoke(value);
+                _value = value;
+            }
         }
 
-        // Adjust background to include mods section title
-        var bg = settingsObjects.FindChild("BG");
-        var bgScale = bg.localScale;
-        bgScale.y += 2.85f;
-        bg.localScale = bgScale;
-        // Also need to remove background of infinite ammo as long as it's
-        // the only thing in its row.
-        Destroy(settingsObjects.FindChild("GOD/INFINITE AMMO/BG (1)").gameObject);
+        public int FontSize;
 
-        bg.gameObject.AddComponent<BoxCollider>();
-        var scrollCollider = new GameObject("Scrolling").transform;
-        scrollCollider.parent = settingsObjects;
-        scrollCollider.rotation = bg.rotation;
-        scrollCollider.localScale = bg.localScale;
-        scrollCollider.gameObject.layer = bg.gameObject.layer;
-        var pos = bg.position;
-        pos.z = 15.0f; // Put collider behind all settings items
-        scrollCollider.position = pos;
-        scrollCollider.gameObject.AddComponent<ScrollSettingsMenu>()
-          .settingsObjects = settingsObjects;
-      }
-      var settingPos = bottomDefaultSetting.position;
+        /// <summary>
+        /// Called on Value change.
+        /// </summary>
+        public SettingsToggle OnToggle;
 
-      settingPos.x += (numRegistered % 2) * SettingSize.x;
-      settingPos.y -= 1.25f + (numRegistered / 2) * SettingSize.y;
-      settingPos.z = 7.0f; // Prevent blocks GUI from being over any toggles
+        private bool _value;
+        internal SettingsComponent settingsComponent;
 
-      var fxaa = settingsObjects.FindChild("SETTINGS/FXAA");
-
-      var newSetting = (Transform)Instantiate(fxaa, settingPos, fxaa.rotation);
-      newSetting.parent = modSection;
-
-      if (numRegistered % 2 == 0)
-      {
-        // Expand background to include new toggle
-        var background = settingsObjects.FindChild("BG");
-        var backgroundScale = background.localScale;
-        backgroundScale.y += SettingSize.y * 2;
-        background.localScale = backgroundScale;
-
-        // Expand the scrolling object to the same size
-        var scrolling = settingsObjects.FindChild("Scrolling");
-        scrolling.localScale = backgroundScale;
-        scrolling.GetComponent<ScrollSettingsMenu>().CalcBounds();
-
-        // Check whether the new element row is outside of the screen
-        // and enable scrolling if it is
-        var lowestPoint = newSetting.position - SettingSize;
-        var cam = GameObject.Find("HUD Cam").GetComponent<Camera>();
-        if (cam.WorldToViewportPoint(lowestPoint).y < 0.0f)
+        public void Destroy()
         {
-          scrolling.GetComponent<ScrollSettingsMenu>().scrollingEnabled = true;
+            Object.Destroy(settingsComponent.gameObject);
         }
-      }
-
-      var newSettingButton = newSetting.FindChild("AA BUTTON");
-      var newSettingText = newSetting.FindChild("AA text");
-      newSetting.gameObject.name = button.text;
-      newSettingButton.gameObject.name = button.text + " button";
-      newSettingText.gameObject.name = button.text + " text";
-      var textMesh = newSettingText.gameObject.GetComponent<TextMesh>();
-      textMesh.text = button.text;
-      textMesh.fontSize = button.fontSize;
-
-      var settingsComponent
-        = newSettingButton.gameObject.AddComponent<SettingsComponent>();
-
-      var fxaaToggle = newSettingButton.gameObject.GetComponent<ToggleAA>();
-      settingsComponent.darkMaterial = fxaaToggle.darkMaterial;
-      settingsComponent.redMaterial = fxaaToggle.redMaterial;
-      Destroy(fxaaToggle);
-
-      settingsComponent.SetCallback(button.cb);
-      settingsComponent.SetOn(button.defaultValue);
-
-      numRegistered++;
     }
-  }
+
+    /// <summary>
+    /// SettingsMenu contains methods for adding a setting (toggle button) to the
+    /// settings drop-down of Besiege.
+    /// </summary>
+    public class SettingsMenu : SingleInstance<SettingsMenu>
+    {
+        public override string Name { get { return "spaar's Mod Loader: Settings Utility"; } }
+
+        private static int numRegistered = 0;
+
+        private static List<SettingsButton> toAdd = new List<SettingsButton>();
+
+        /// <summary>
+        /// Registers a new toggle button. It will be placed below all others
+        /// that are currently registered.
+        /// </summary>
+        /// <param name="text">The text to display on the button</param>
+        /// <param name="cb">Callback to call when the button is clicked</param>
+        /// <param name="defaultValue">Starting state of the toggle</param>
+        /// <param name="fontSize">Font size of the text on the button</param>
+        public static void RegisterSettingsButton(string text, SettingsToggle cb,
+          bool defaultValue = false, int fontSize = 0)
+        {
+            var button = new SettingsButton()
+            {
+                Text = text,
+                OnToggle = cb,
+                Value = defaultValue,
+                FontSize = fontSize
+            };
+            toAdd.Add(button);
+
+            if (Game.AddPiece != null)
+                RegisterSettingsButtonInternal(button);
+        }
+
+        public static void RegisterSettingsButton(SettingsButton button)
+        {
+            toAdd.Add(button);
+
+            if (Game.AddPiece != null)
+                RegisterSettingsButtonInternal(button);
+        }
+
+        private void Start()
+        {
+            Internal.ModLoader.MakeModule(this);
+
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (Game.AddPiece != null)
+            {
+                numRegistered = 0;
+                foreach (var button in toAdd)
+                {
+                    RegisterSettingsButtonInternal(button);
+                }
+            }
+        }
+
+        private static Transform modSection;
+
+        private static void RegisterSettingsButtonInternal(SettingsButton button)
+        {
+            var settingsObjects = GameObject.Find("Settings").transform
+              .FindChild("SettingsObjects");
+            var bottomDefaultSetting = settingsObjects.FindChild("GOD/INFINITE AMMO");
+            Vector3 SettingSize = new Vector3(0.748f, 0.375f);
+
+            if (modSection == null)
+            {
+                // Create a MODS section
+                var settings = settingsObjects.FindChild("SETTINGS");
+
+                var modsPos = settings.position;
+                modsPos.y = bottomDefaultSetting.position.y - 1.2f;
+                modsPos.z = 7.0f; // Prevent blocks GUI from being over the toggles
+
+                modSection = (Transform)Instantiate(settings, modsPos,
+                  settings.rotation);
+                modSection.parent = settingsObjects;
+                modSection.name = "MOD SETTINGS";
+
+                foreach (Transform child in modSection)
+                {
+                    if (child.name == "GENERAL")
+                    {
+                        child.GetComponent<TextMesh>().text = "M O D S";
+                        child.name = "Title";
+                    }
+                    else
+                    {
+                        Destroy(child.gameObject);
+                    }
+                }
+
+                // Adjust background to include mods section title
+                var bg = settingsObjects.FindChild("BG");
+                var bgScale = bg.localScale;
+                bgScale.y += 2.85f;
+                bg.localScale = bgScale;
+                // Also need to remove background of infinite ammo as long as it's
+                // the only thing in its row.
+                Destroy(settingsObjects.FindChild("GOD/INFINITE AMMO/BG (1)").gameObject);
+
+                bg.gameObject.AddComponent<BoxCollider>();
+                var scrollCollider = new GameObject("Scrolling").transform;
+                scrollCollider.parent = settingsObjects;
+                scrollCollider.rotation = bg.rotation;
+                scrollCollider.localScale = bg.localScale;
+                scrollCollider.gameObject.layer = bg.gameObject.layer;
+                var pos = bg.position;
+                pos.z = 15.0f; // Put collider behind all settings items
+                scrollCollider.position = pos;
+                scrollCollider.gameObject.AddComponent<ScrollSettingsMenu>()
+                  .settingsObjects = settingsObjects;
+            }
+            var settingPos = bottomDefaultSetting.position;
+
+            settingPos.x += (numRegistered % 2) * SettingSize.x;
+            settingPos.y -= 1.25f + (numRegistered / 2) * SettingSize.y;
+            settingPos.z = 7.0f; // Prevent blocks GUI from being over any toggles
+
+            var fxaa = settingsObjects.FindChild("SETTINGS/FXAA");
+
+            var newSetting = (Transform)Instantiate(fxaa, settingPos, fxaa.rotation);
+            newSetting.parent = modSection;
+
+            if (numRegistered % 2 == 0)
+            {
+                // Expand background to include new toggle
+                var background = settingsObjects.FindChild("BG");
+                var backgroundScale = background.localScale;
+                backgroundScale.y += SettingSize.y * 2;
+                background.localScale = backgroundScale;
+
+                // Expand the scrolling object to the same size
+                var scrolling = settingsObjects.FindChild("Scrolling");
+                scrolling.localScale = backgroundScale;
+                scrolling.GetComponent<ScrollSettingsMenu>().CalcBounds();
+
+                // Check whether the new element row is outside of the screen
+                // and enable scrolling if it is
+                var lowestPoint = newSetting.position - SettingSize;
+                var cam = GameObject.Find("HUD Cam").GetComponent<Camera>();
+                if (cam.WorldToViewportPoint(lowestPoint).y < 0.0f)
+                {
+                    scrolling.GetComponent<ScrollSettingsMenu>().scrollingEnabled = true;
+                }
+            }
+
+            var newSettingButton = newSetting.FindChild("AA BUTTON");
+            var newSettingText = newSetting.FindChild("AA text");
+            newSetting.gameObject.name = button.Text;
+            newSettingButton.gameObject.name = button.Text + " button";
+            newSettingText.gameObject.name = button.Text + " text";
+            var textMesh = newSettingText.gameObject.GetComponent<TextMesh>();
+            textMesh.text = button.Text;
+            textMesh.fontSize = button.FontSize;
+
+            var settingsComponent
+              = newSettingButton.gameObject.AddComponent<SettingsComponent>();
+
+            var fxaaToggle = newSettingButton.gameObject.GetComponent<ToggleAA>();
+            settingsComponent.darkMaterial = fxaaToggle.darkMaterial;
+            settingsComponent.redMaterial = fxaaToggle.redMaterial;
+            Destroy(fxaaToggle);
+
+            settingsComponent.SetCallback(button.OnToggle);
+            settingsComponent.SetOn(button.Value);
+
+            // Pass settings component reference to button.
+            button.settingsComponent = settingsComponent;
+
+            numRegistered++;
+        }
+    }
 }


### PR DESCRIPTION
Allows mods to keep reference and update values, text, font sizes of SettingButton and OptionButton instances. Also allows them to destroy them.

Deprecates old register functions but maintains compatibility. New way of registering buttons would now be:
```cs
var button = new SettingsButton
{
    Text = "MyButton",
    FontSize = 13,
    Value = true, // default false
    OnToggle = value => Debug.Log("MyButton was toggled to "+value);
};
button.Create();
```

After creation, changing the button properties also changes the button visually.
Button can be removed by calling `button.Destroy()`.

