### PR TITLE
Harmony integration, minor build tweaks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 spaar
+Copyright (c) 2017 spaar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,27 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+Harmony License
+===============
+Copyright (c) 2017 Andreas Pardeike
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 Mono.Cecil License
 ==================

--- a/ModLoader/Harmony/Attributes.cs
+++ b/ModLoader/Harmony/Attributes.cs
@@ -1,0 +1,100 @@
+﻿using System;
+
+namespace Harmony
+{
+	public class HarmonyAttribute : Attribute
+	{
+		public HarmonyMethod info = new HarmonyMethod();
+	}
+
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+	public class HarmonyPatch : HarmonyAttribute
+	{
+		public HarmonyPatch()
+		{
+		}
+
+		public HarmonyPatch(Type type)
+		{
+			info.originalType = type;
+		}
+
+		public HarmonyPatch(string methodName)
+		{
+			info.methodName = methodName;
+		}
+
+		public HarmonyPatch(Type[] parameter)
+		{
+			info.parameter = parameter;
+		}
+
+		public HarmonyPatch(Type type, string methodName, Type[] parameter = null)
+		{
+			info.originalType = type;
+			info.methodName = methodName;
+			info.parameter = parameter;
+		}
+
+		public HarmonyPatch(Type type, Type[] parameter = null)
+		{
+			info.originalType = type;
+			info.parameter = parameter;
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+	public class HarmonyPriority : HarmonyAttribute
+	{
+		public HarmonyPriority(int prioritiy)
+		{
+			info.prioritiy = prioritiy;
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+	public class HarmonyBefore : HarmonyAttribute
+	{
+		public HarmonyBefore(params string[] before)
+		{
+			info.before = before;
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+	public class HarmonyAfter : HarmonyAttribute
+	{
+		public HarmonyAfter(params string[] after)
+		{
+			info.after = after;
+		}
+	}
+
+	// If you don't want to use the special method names you can annotate
+	// using the following attributes:
+
+	[AttributeUsage(AttributeTargets.Method)]
+	public class HarmonyPrepare : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method)]
+	public class HarmonyTargetMethod : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method)]
+	public class HarmonyPrefix : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method)]
+	public class HarmonyPostfix : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method)]
+	public class HarmonyTranspiler : Attribute
+	{
+	}
+}

--- a/ModLoader/Harmony/CodeInstruction.cs
+++ b/ModLoader/Harmony/CodeInstruction.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	public class CodeInstruction
+	{
+		public OpCode opcode;
+		public object operand;
+		public List<Label> labels = new List<Label>();
+
+		public CodeInstruction(OpCode opcode, object operand = null)
+		{
+			this.opcode = opcode;
+			this.operand = operand;
+		}
+
+		public CodeInstruction(CodeInstruction instruction)
+		{
+			opcode = instruction.opcode;
+			operand = instruction.operand;
+			labels = instruction.labels.ToArray().ToList();
+		}
+
+		public override string ToString()
+		{
+			return string.Format(opcode + " " + operand);
+		}
+	}
+}

--- a/ModLoader/Harmony/CodeTranspiler.cs
+++ b/ModLoader/Harmony/CodeTranspiler.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using Harmony.ILCopying;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System;
+using System.Collections;
+
+namespace Harmony
+{
+	public class CodeTranspiler
+	{
+		private IEnumerable<CodeInstruction> codeInstructions;
+		private List<MethodInfo> transpilers = new List<MethodInfo>();
+
+		public CodeTranspiler(List<ILInstruction> ilInstructions)
+		{
+			codeInstructions = ilInstructions
+				.Select(ilInstruction => ilInstruction.GetCodeInstruction())
+				.ToList().AsEnumerable();
+		}
+
+		public void Add(MethodInfo transpiler)
+		{
+			transpilers.Add(transpiler);
+		}
+
+		public static IEnumerable ConvertInstructions(Type type, IEnumerable enumerable)
+		{
+			var enumerableAssembly = type.GetGenericTypeDefinition().Assembly;
+			var genericListType = enumerableAssembly.GetType(typeof(List<>).FullName);
+			var elementType = type.GetGenericArguments()[0];
+			var listType = enumerableAssembly.GetType(genericListType.MakeGenericType(new Type[] { elementType }).FullName);
+			var list = Activator.CreateInstance(listType);
+			var listAdd = list.GetType().GetMethod("Add");
+
+			foreach (var op in enumerable)
+			{
+				var elementTo = Activator.CreateInstance(elementType, new object[] { OpCodes.Nop, null });
+				Traverse.IterateFields(op, elementTo, (trvFrom, trvDest) => trvDest.SetValue(trvFrom.GetValue()));
+				listAdd.Invoke(list, new object[] { elementTo });
+			}
+			return list as IEnumerable;
+		}
+
+		public static IEnumerable ConvertInstructions(MethodInfo transpiler, IEnumerable enumerable)
+		{
+			var type = transpiler.GetParameters()
+				  .Select(p => p.ParameterType)
+				  .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition().Name.StartsWith("IEnumerable"));
+			return ConvertInstructions(type, enumerable);
+		}
+
+		public IEnumerable<CodeInstruction> GetResult(ILGenerator generator, MethodBase method)
+		{
+			IEnumerable instructions = codeInstructions;
+			transpilers.ForEach(transpiler =>
+			{
+				instructions = ConvertInstructions(transpiler, instructions);
+				var parameter = new List<object>();
+				transpiler.GetParameters().Select(param => param.ParameterType).Do(type =>
+				{
+					if (type.IsAssignableFrom(typeof(ILGenerator)))
+						parameter.Add(generator);
+					else if (type.IsAssignableFrom(typeof(MethodBase)))
+						parameter.Add(method);
+					else
+						parameter.Add(instructions);
+				});
+				instructions = transpiler.Invoke(null, parameter.ToArray()) as IEnumerable;
+			});
+			instructions = ConvertInstructions(typeof(IEnumerable<CodeInstruction>), instructions);
+			return instructions as IEnumerable<CodeInstruction>;
+		}
+	}
+}

--- a/ModLoader/Harmony/Extras/DelegateTypeFactory.cs
+++ b/ModLoader/Harmony/Extras/DelegateTypeFactory.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	class DelegateTypeFactory
+	{
+		readonly ModuleBuilder module;
+
+		static int counter;
+		public DelegateTypeFactory()
+		{
+			counter++;
+			var name = new AssemblyName("HarmonyDTFAssembly" + counter);
+			var assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run);
+			module = assembly.DefineDynamicModule("HarmonyDTFModule" + counter);
+		}
+
+		public Type CreateDelegateType(MethodInfo method)
+		{
+			var attr = TypeAttributes.Sealed | TypeAttributes.Public;
+			var typeBuilder = module.DefineType("HarmonyDTFType" + counter, attr, typeof(MulticastDelegate));
+
+			var constructor = typeBuilder.DefineConstructor(
+				 MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public,
+				 CallingConventions.Standard, new[] { typeof(object), typeof(IntPtr) });
+			constructor.SetImplementationFlags(MethodImplAttributes.CodeTypeMask);
+
+			var parameters = method.GetParameters();
+
+			var invokeMethod = typeBuilder.DefineMethod(
+				 "Invoke", MethodAttributes.HideBySig | MethodAttributes.Virtual | MethodAttributes.Public,
+				 method.ReturnType, parameters.Types());
+			invokeMethod.SetImplementationFlags(MethodImplAttributes.CodeTypeMask);
+
+			for (int i = 0; i < parameters.Length; i++)
+				invokeMethod.DefineParameter(i + 1, ParameterAttributes.None, parameters[i].Name);
+
+			return typeBuilder.CreateType();
+		}
+	}
+}

--- a/ModLoader/Harmony/Extras/FastAccess.cs
+++ b/ModLoader/Harmony/Extras/FastAccess.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	// Based on https://www.codeproject.com/Articles/14973/Dynamic-Code-Generation-vs-Reflection
+
+	public delegate object GetterHandler(object source);
+	public delegate void SetterHandler(object source, object value);
+	public delegate object InstantiationHandler();
+
+	class FastAccess
+	{
+		public static InstantiationHandler CreateInstantiationHandler(Type type)
+		{
+			var constructorInfo = type.GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[0], null);
+			if (constructorInfo == null)
+			{
+				throw new ApplicationException(string.Format("The type {0} must declare an empty constructor (the constructor may be private, internal, protected, protected internal, or public).", type));
+			}
+
+			var dynamicMethod = new DynamicMethod("InstantiateObject_" + type.Name, MethodAttributes.Static | MethodAttributes.Public, CallingConventions.Standard, typeof(object), null, type, true);
+			var generator = dynamicMethod.GetILGenerator();
+			generator.Emit(OpCodes.Newobj, constructorInfo);
+			generator.Emit(OpCodes.Ret);
+			return (InstantiationHandler)dynamicMethod.CreateDelegate(typeof(InstantiationHandler));
+		}
+
+		public static GetterHandler CreateGetterHandler(PropertyInfo propertyInfo)
+		{
+			var getMethodInfo = propertyInfo.GetGetMethod(true);
+			var dynamicGet = CreateGetDynamicMethod(propertyInfo.DeclaringType);
+			var getGenerator = dynamicGet.GetILGenerator();
+
+			getGenerator.Emit(OpCodes.Ldarg_0);
+			getGenerator.Emit(OpCodes.Call, getMethodInfo);
+			BoxIfNeeded(getMethodInfo.ReturnType, getGenerator);
+			getGenerator.Emit(OpCodes.Ret);
+
+			return (GetterHandler)dynamicGet.CreateDelegate(typeof(GetterHandler));
+		}
+
+		public static GetterHandler CreateGetterHandler(FieldInfo fieldInfo)
+		{
+			var dynamicGet = CreateGetDynamicMethod(fieldInfo.DeclaringType);
+			var getGenerator = dynamicGet.GetILGenerator();
+
+			getGenerator.Emit(OpCodes.Ldarg_0);
+			getGenerator.Emit(OpCodes.Ldfld, fieldInfo);
+			BoxIfNeeded(fieldInfo.FieldType, getGenerator);
+			getGenerator.Emit(OpCodes.Ret);
+
+			return (GetterHandler)dynamicGet.CreateDelegate(typeof(GetterHandler));
+		}
+
+		public static SetterHandler CreateSetterHandler(PropertyInfo propertyInfo)
+		{
+			var setMethodInfo = propertyInfo.GetSetMethod(true);
+			var dynamicSet = CreateSetDynamicMethod(propertyInfo.DeclaringType);
+			var setGenerator = dynamicSet.GetILGenerator();
+
+			setGenerator.Emit(OpCodes.Ldarg_0);
+			setGenerator.Emit(OpCodes.Ldarg_1);
+			UnboxIfNeeded(setMethodInfo.GetParameters()[0].ParameterType, setGenerator);
+			setGenerator.Emit(OpCodes.Call, setMethodInfo);
+			setGenerator.Emit(OpCodes.Ret);
+
+			return (SetterHandler)dynamicSet.CreateDelegate(typeof(SetterHandler));
+		}
+
+		public static SetterHandler CreateSetterHandler(FieldInfo fieldInfo)
+		{
+			var dynamicSet = CreateSetDynamicMethod(fieldInfo.DeclaringType);
+			var setGenerator = dynamicSet.GetILGenerator();
+
+			setGenerator.Emit(OpCodes.Ldarg_0);
+			setGenerator.Emit(OpCodes.Ldarg_1);
+			UnboxIfNeeded(fieldInfo.FieldType, setGenerator);
+			setGenerator.Emit(OpCodes.Stfld, fieldInfo);
+			setGenerator.Emit(OpCodes.Ret);
+
+			return (SetterHandler)dynamicSet.CreateDelegate(typeof(SetterHandler));
+		}
+
+		//
+
+		static DynamicMethod CreateGetDynamicMethod(Type type)
+		{
+			return new DynamicMethod("DynamicGet_" + type.Name, typeof(object), new Type[] { typeof(object) }, type, true);
+		}
+
+		static DynamicMethod CreateSetDynamicMethod(Type type)
+		{
+			return new DynamicMethod("DynamicSet_" + type.Name, typeof(void), new Type[] { typeof(object), typeof(object) }, type, true);
+		}
+
+		static void BoxIfNeeded(Type type, ILGenerator generator)
+		{
+			if (type.IsValueType)
+				generator.Emit(OpCodes.Box, type);
+		}
+
+		static void UnboxIfNeeded(Type type, ILGenerator generator)
+		{
+			if (type.IsValueType)
+				generator.Emit(OpCodes.Unbox_Any, type);
+		}
+	}
+}

--- a/ModLoader/Harmony/Extras/MethodInvoker.cs
+++ b/ModLoader/Harmony/Extras/MethodInvoker.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	// Based on https://www.codeproject.com/Articles/14593/A-General-Fast-Method-Invoker
+
+	public delegate object FastInvokeHandler(object target, object[] paramters);
+
+	class MethodInvoker
+	{
+		public static FastInvokeHandler GetHandler(DynamicMethod methodInfo, Module module)
+		{
+			return Handler(methodInfo, module);
+		}
+
+		public static FastInvokeHandler GetHandler(MethodInfo methodInfo)
+		{
+			return Handler(methodInfo, methodInfo.DeclaringType.Module);
+		}
+
+		static FastInvokeHandler Handler(MethodInfo methodInfo, Module module)
+		{
+			var dynamicMethod = new DynamicMethod("FastInvoke_" + methodInfo.Name, typeof(object), new Type[] { typeof(object), typeof(object[]) }, module);
+			var il = dynamicMethod.GetILGenerator();
+
+			var ps = methodInfo.GetParameters();
+			var paramTypes = new Type[ps.Length];
+			for (int i = 0; i < paramTypes.Length; i++)
+			{
+				if (ps[i].ParameterType.IsByRef)
+					paramTypes[i] = ps[i].ParameterType.GetElementType();
+				else
+					paramTypes[i] = ps[i].ParameterType;
+			}
+
+			var locals = new LocalBuilder[paramTypes.Length];
+			for (int i = 0; i < paramTypes.Length; i++)
+				locals[i] = il.DeclareLocal(paramTypes[i], true);
+
+			for (int i = 0; i < paramTypes.Length; i++)
+			{
+				il.Emit(OpCodes.Ldarg_1);
+				EmitFastInt(il, i);
+				il.Emit(OpCodes.Ldelem_Ref);
+				EmitCastToReference(il, paramTypes[i]);
+				il.Emit(OpCodes.Stloc, locals[i]);
+			}
+
+			if (!methodInfo.IsStatic)
+				il.Emit(OpCodes.Ldarg_0);
+
+			for (int i = 0; i < paramTypes.Length; i++)
+			{
+				if (ps[i].ParameterType.IsByRef)
+					il.Emit(OpCodes.Ldloca_S, locals[i]);
+				else
+					il.Emit(OpCodes.Ldloc, locals[i]);
+			}
+
+#pragma warning disable XS0001
+			if (methodInfo.IsStatic)
+				il.EmitCall(OpCodes.Call, methodInfo, null);
+			else
+				il.EmitCall(OpCodes.Callvirt, methodInfo, null);
+#pragma warning restore XS0001
+
+			if (methodInfo.ReturnType == typeof(void))
+				il.Emit(OpCodes.Ldnull);
+			else
+				EmitBoxIfNeeded(il, methodInfo.ReturnType);
+
+			for (int i = 0; i < paramTypes.Length; i++)
+			{
+				if (ps[i].ParameterType.IsByRef)
+				{
+					il.Emit(OpCodes.Ldarg_1);
+					EmitFastInt(il, i);
+					il.Emit(OpCodes.Ldloc, locals[i]);
+					if (locals[i].LocalType.IsValueType)
+						il.Emit(OpCodes.Box, locals[i].LocalType);
+					il.Emit(OpCodes.Stelem_Ref);
+				}
+			}
+
+			il.Emit(OpCodes.Ret);
+
+			var invoder = (FastInvokeHandler)dynamicMethod.CreateDelegate(typeof(FastInvokeHandler));
+			return invoder;
+		}
+
+		static void EmitCastToReference(ILGenerator il, Type type)
+		{
+			if (type.IsValueType)
+				il.Emit(OpCodes.Unbox_Any, type);
+			else
+				il.Emit(OpCodes.Castclass, type);
+		}
+
+		static void EmitBoxIfNeeded(ILGenerator il, Type type)
+		{
+			if (type.IsValueType)
+				il.Emit(OpCodes.Box, type);
+		}
+
+		static void EmitFastInt(ILGenerator il, int value)
+		{
+			switch (value)
+			{
+				case -1:
+					il.Emit(OpCodes.Ldc_I4_M1);
+					return;
+				case 0:
+					il.Emit(OpCodes.Ldc_I4_0);
+					return;
+				case 1:
+					il.Emit(OpCodes.Ldc_I4_1);
+					return;
+				case 2:
+					il.Emit(OpCodes.Ldc_I4_2);
+					return;
+				case 3:
+					il.Emit(OpCodes.Ldc_I4_3);
+					return;
+				case 4:
+					il.Emit(OpCodes.Ldc_I4_4);
+					return;
+				case 5:
+					il.Emit(OpCodes.Ldc_I4_5);
+					return;
+				case 6:
+					il.Emit(OpCodes.Ldc_I4_6);
+					return;
+				case 7:
+					il.Emit(OpCodes.Ldc_I4_7);
+					return;
+				case 8:
+					il.Emit(OpCodes.Ldc_I4_8);
+					return;
+			}
+
+			if (value > -129 && value < 128)
+				il.Emit(OpCodes.Ldc_I4_S, (sbyte)value);
+			else
+				il.Emit(OpCodes.Ldc_I4, value);
+		}
+	}
+}

--- a/ModLoader/Harmony/HarmonyInstance.cs
+++ b/ModLoader/Harmony/HarmonyInstance.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+
+namespace Harmony
+{
+	public class Patches
+	{
+		public readonly ReadOnlyCollection<Patch> Prefixes;
+		public readonly ReadOnlyCollection<Patch> Postfixes;
+
+		public ReadOnlyCollection<string> Owners
+		{
+			get
+			{
+				var result = new HashSet<string>();
+				result.UnionWith(Prefixes.Select(p => p.owner));
+				result.UnionWith(Postfixes.Select(p => p.owner));
+				return result.ToList().AsReadOnly();
+			}
+		}
+
+		public Patches(Patch[] prefixes, Patch[] postfixes)
+		{
+			if (prefixes == null) prefixes = new Patch[0];
+			if (postfixes == null) postfixes = new Patch[0];
+
+			Prefixes = prefixes.ToList().AsReadOnly();
+			Postfixes = postfixes.ToList().AsReadOnly();
+		}
+	}
+
+	public class HarmonyInstance
+	{
+		readonly string id;
+		public string Id => id;
+		public static bool DEBUG = false;
+
+		HarmonyInstance(string id)
+		{
+			this.id = id;
+		}
+
+		public static HarmonyInstance Create(string id)
+		{
+			if (id == null) throw new Exception("id cannot be null");
+			return new HarmonyInstance(id);
+		}
+
+		public void PatchAll(Assembly assembly)
+		{
+            var types = assembly.GetTypes();
+            foreach (var type in types)
+            {
+                var parentMethodInfos = type.GetHarmonyMethods();
+                if (parentMethodInfos != null && parentMethodInfos.Count() > 0)
+                {
+                    var info = HarmonyMethod.Merge(parentMethodInfos);
+                    var processor = new PatchProcessor(this, type, info);
+                    processor.Patch();
+                }
+            }
+		}
+
+		public void Patch(MethodBase original, HarmonyMethod prefix, HarmonyMethod postfix, HarmonyMethod transpiler = null)
+		{
+			var processor = new PatchProcessor(this, original, prefix, postfix, transpiler);
+			processor.Patch();
+		}
+
+		public Patches IsPatched(MethodBase method)
+		{
+			return PatchProcessor.IsPatched(method);
+		}
+	}
+}

--- a/ModLoader/Harmony/HarmonyMethod.cs
+++ b/ModLoader/Harmony/HarmonyMethod.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	public class HarmonyMethod
+	{
+		public MethodInfo method; // need to be called 'method'
+
+		public Type originalType;
+		public string methodName;
+		public Type[] parameter;
+		public int prioritiy = -1;
+		public string[] before;
+		public string[] after;
+
+		public HarmonyMethod()
+		{
+		}
+
+		void ImportMethod(MethodInfo theMethod)
+		{
+			method = theMethod;
+			if (method != null)
+			{
+				var infos = method.GetHarmonyMethods();
+				if (infos != null)
+					Merge(infos).CopyTo(this);
+			}
+		}
+
+		public HarmonyMethod(MethodInfo method)
+		{
+			ImportMethod(method);
+		}
+
+		public HarmonyMethod(Type type, string name, Type[] parameters = null)
+		{
+			var method = AccessTools.Method(type, name, parameters);
+			ImportMethod(method);
+		}
+
+		public static List<string> HarmonyFields()
+		{
+			return AccessTools
+				.GetFieldNames(typeof(HarmonyMethod))
+				.Where(s => s != "method")
+				.ToList();
+		}
+
+		public static HarmonyMethod Merge(List<HarmonyMethod> attributes)
+		{
+			var result = new HarmonyMethod();
+			if (attributes == null) return result;
+			var resultTrv = Traverse.Create(result);
+			attributes.ForEach(attribute =>
+			{
+				var trv = Traverse.Create(attribute);
+				HarmonyFields().ForEach(f =>
+				{
+					var val = trv.Field(f).GetValue();
+					if (val != null)
+						resultTrv.Field(f).SetValue(val);
+				});
+			});
+			return result;
+		}
+	}
+
+	public static class HarmonyMethodExtensions
+	{
+		public static void CopyTo(this HarmonyMethod from, HarmonyMethod to)
+		{
+			if (to == null) return;
+			var fromTrv = Traverse.Create(from);
+			var toTrv = Traverse.Create(to);
+			HarmonyMethod.HarmonyFields().ForEach(f =>
+			{
+				var val = fromTrv.Field(f).GetValue();
+				if (val != null) toTrv.Field(f).SetValue(val);
+			});
+		}
+
+		public static HarmonyMethod Clone(this HarmonyMethod original)
+		{
+			var result = new HarmonyMethod();
+			original.CopyTo(result);
+			return result;
+		}
+
+		public static HarmonyMethod Merge(this HarmonyMethod master, HarmonyMethod detail)
+		{
+			if (detail == null) return master;
+			var result = new HarmonyMethod();
+			var resultTrv = Traverse.Create(result);
+			var masterTrv = Traverse.Create(master);
+			var detailTrv = Traverse.Create(detail);
+			HarmonyMethod.HarmonyFields().ForEach(f =>
+			{
+				var baseValue = masterTrv.Field(f).GetValue();
+				var detailValue = detailTrv.Field(f).GetValue();
+				resultTrv.Field(f).SetValue(detailValue ?? baseValue);
+			});
+			return result;
+		}
+
+		public static List<HarmonyMethod> GetHarmonyMethods(this Type type)
+		{
+			return type.GetCustomAttributes(true)
+						.Where(attr => attr is HarmonyAttribute)
+						.Cast<HarmonyAttribute>()
+						.Select(attr => attr.info)
+						.ToList();
+		}
+
+		public static List<HarmonyMethod> GetHarmonyMethods(this MethodBase method)
+		{
+			if (method is DynamicMethod) return new List<HarmonyMethod>();
+			return method.GetCustomAttributes(true)
+						.Where(attr => attr is HarmonyAttribute)
+						.Cast<HarmonyAttribute>()
+						.Select(attr => attr.info)
+						.ToList();
+		}
+	}
+}

--- a/ModLoader/Harmony/HarmonySharedState.cs
+++ b/ModLoader/Harmony/HarmonySharedState.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	public static class HarmonySharedState
+	{
+		static readonly string name = "HarmonySharedState";
+		public static readonly int internalVersion = 100;
+		public static int actualVersion = -1;
+
+		static Dictionary<MethodBase, byte[]> GetState()
+		{
+			lock (name)
+			{
+				var assembly = SharedStateAssembly();
+				if (assembly == null)
+				{
+					var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+					var moduleBuilder = assemblyBuilder.DefineDynamicModule(name);
+					var typeAttributes = TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.Abstract;
+					var typeBuilder = moduleBuilder.DefineType(name, typeAttributes);
+					typeBuilder.DefineField("state", typeof(Dictionary<MethodBase, byte[]>), FieldAttributes.Static | FieldAttributes.Public);
+					typeBuilder.DefineField("version", typeof(int), FieldAttributes.Static | FieldAttributes.Public).SetConstant(internalVersion);
+					typeBuilder.CreateType();
+
+					assembly = SharedStateAssembly();
+					if (assembly == null) throw new Exception("Cannot find or create harmony shared state");
+				}
+
+				var versionField = assembly.GetType(name).GetField("version");
+				if (versionField == null) throw new Exception("Cannot find harmony state version field");
+				actualVersion = (int)versionField.GetValue(null);
+
+				var stateField = assembly.GetType(name).GetField("state");
+				if (stateField == null) throw new Exception("Cannot find harmony state field");
+				if (stateField.GetValue(null) == null) stateField.SetValue(null, new Dictionary<MethodBase, byte[]>());
+				return (Dictionary<MethodBase, byte[]>)stateField.GetValue(null);
+			}
+		}
+
+		static Assembly SharedStateAssembly()
+		{
+			return AppDomain.CurrentDomain.GetAssemblies()
+				.FirstOrDefault(a => a.GetName().Name.Contains(name));
+		}
+
+		public static PatchInfo GetPatchInfo(MethodBase method)
+		{
+			var bytes = GetState().GetValueSafe(method);
+			if (bytes == null) return null;
+			return PatchInfoSerialization.Deserialize(bytes);
+		}
+
+		public static void UpdatePatchInfo(MethodBase method, PatchInfo patchInfo)
+		{
+			GetState()[method] = patchInfo.Serialize();
+		}
+	}
+}

--- a/ModLoader/Harmony/ILCopying/ByteBuffer.cs
+++ b/ModLoader/Harmony/ILCopying/ByteBuffer.cs
@@ -1,0 +1,104 @@
+﻿using System;
+
+namespace Harmony.ILCopying
+{
+	public class ByteBuffer
+	{
+		public byte[] buffer;
+		public int position;
+
+		public ByteBuffer(byte[] buffer)
+		{
+			this.buffer = buffer;
+		}
+
+		public byte ReadByte()
+		{
+			CheckCanRead(1);
+			return buffer[position++];
+		}
+
+		public byte[] ReadBytes(int length)
+		{
+			CheckCanRead(length);
+			var value = new byte[length];
+			Buffer.BlockCopy(buffer, position, value, 0, length);
+			position += length;
+			return value;
+		}
+
+		public short ReadInt16()
+		{
+			CheckCanRead(2);
+			var value = (short)(buffer[position]
+				| (buffer[position + 1] << 8));
+			position += 2;
+			return value;
+		}
+
+		public int ReadInt32()
+		{
+			CheckCanRead(4);
+			int value = buffer[position]
+				| (buffer[position + 1] << 8)
+				| (buffer[position + 2] << 16)
+				| (buffer[position + 3] << 24);
+			position += 4;
+			return value;
+		}
+
+		public long ReadInt64()
+		{
+			CheckCanRead(8);
+			var low = (uint)(buffer[position]
+				| (buffer[position + 1] << 8)
+				| (buffer[position + 2] << 16)
+				| (buffer[position + 3] << 24));
+
+			var high = (uint)(buffer[position + 4]
+				| (buffer[position + 5] << 8)
+				| (buffer[position + 6] << 16)
+				| (buffer[position + 7] << 24));
+
+			long value = (((long)high) << 32) | low;
+			position += 8;
+			return value;
+		}
+
+		public float ReadSingle()
+		{
+			if (!BitConverter.IsLittleEndian)
+			{
+				var bytes = ReadBytes(4);
+				Array.Reverse(bytes);
+				return BitConverter.ToSingle(bytes, 0);
+			}
+
+			CheckCanRead(4);
+			var value = BitConverter.ToSingle(buffer, position);
+			position += 4;
+			return value;
+		}
+
+		public double ReadDouble()
+		{
+			if (!BitConverter.IsLittleEndian)
+			{
+				var bytes = ReadBytes(8);
+				Array.Reverse(bytes);
+				return BitConverter.ToDouble(bytes, 0);
+			}
+
+			CheckCanRead(8);
+			var value = BitConverter.ToDouble(buffer, position);
+			position += 8;
+			return value;
+		}
+
+		void CheckCanRead(int count)
+		{
+			if (position + count > buffer.Length)
+				throw new ArgumentOutOfRangeException();
+		}
+	}
+}

--- a/ModLoader/Harmony/ILCopying/Emitter.cs
+++ b/ModLoader/Harmony/ILCopying/Emitter.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+
+namespace Harmony.ILCopying
+{
+	public static class Emitter
+	{
+		public static string CodePos(ILGenerator il)
+		{
+			var offset = Traverse.Create(il).Field("code_len").GetValue<int>();
+			return "L_" + offset.ToString("x4") + ": ";
+		}
+
+		public static void LogLastLocalVariable(ILGenerator il)
+		{
+			if (HarmonyInstance.DEBUG)
+			{
+				var existingLocals = Traverse.Create(il).Field("locals").GetValue<LocalBuilder[]>();
+				if (existingLocals.Length > 0)
+				{
+					var latestVar = existingLocals.Last();
+					FileLog.Log(CodePos(il) + "Local var #" + (existingLocals.Length - 1) + " " + latestVar.LocalType.FullName + (latestVar.IsPinned ? "(pinned)" : ""));
+				}
+			}
+		}
+
+		public static string FormatArgument(object argument)
+		{
+			if (argument == null) return "NULL";
+			var type = argument.GetType();
+
+			if (type == typeof(string))
+				return "\"" + argument + "\"";
+			if (type == typeof(Label))
+				return "Label #" + ((Label)argument).GetHashCode();
+			if (type == typeof(Label[]))
+				return "Labels " + string.Join(" ", ((Label[])argument).Select(l => "#" + l.GetHashCode()).ToArray());
+			if (type == typeof(LocalBuilder))
+				return ((LocalBuilder)argument).LocalIndex + " (" + ((LocalBuilder)argument).LocalType + ")";
+
+			return "" + argument;
+		}
+
+		public static void MarkLabel(ILGenerator il, Label label)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + FormatArgument(label));
+			il.MarkLabel(label);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode);
+			il.Emit(opcode);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, LocalBuilder local)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(local));
+			il.Emit(opcode, local);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, FieldInfo field)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(field));
+			il.Emit(opcode, field);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, Label[] labels)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(labels));
+			il.Emit(opcode, labels);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, Label label)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(label));
+			il.Emit(opcode, label);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, string str)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + FormatArgument(str));
+			il.Emit(opcode, str);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, float arg)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(arg));
+			il.Emit(opcode, arg);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, byte arg)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(arg));
+			il.Emit(opcode, arg);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, sbyte arg)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(arg));
+			il.Emit(opcode, arg);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, double arg)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(arg));
+			il.Emit(opcode, arg);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, int arg)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(arg));
+			il.Emit(opcode, arg);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, MethodInfo meth)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(meth));
+			il.Emit(opcode, meth);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, short arg)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(arg));
+			il.Emit(opcode, arg);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, SignatureHelper signature)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(signature));
+			il.Emit(opcode, signature);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, ConstructorInfo con)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(con));
+			il.Emit(opcode, con);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, Type cls)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(cls));
+			il.Emit(opcode, cls);
+		}
+
+		public static void Emit(ILGenerator il, OpCode opcode, long arg)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + opcode + " " + FormatArgument(arg));
+			il.Emit(opcode, arg);
+		}
+
+		public static void EmitCall(ILGenerator il, OpCode opcode, MethodInfo methodInfo, Type[] optionalParameterTypes)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + "Call " + opcode + " " + methodInfo + " " + optionalParameterTypes);
+			il.EmitCall(opcode, methodInfo, optionalParameterTypes);
+		}
+
+		public static void EmitCalli(ILGenerator il, OpCode opcode, CallingConvention unmanagedCallConv, Type returnType, Type[] parameterTypes)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + "Calli " + opcode + " " + unmanagedCallConv + " " + returnType + " " + parameterTypes);
+			il.EmitCalli(opcode, unmanagedCallConv, returnType, parameterTypes);
+		}
+
+		public static void EmitCalli(ILGenerator il, OpCode opcode, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, Type[] optionalParameterTypes)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + "Calli " + opcode + " " + callingConvention + " " + returnType + " " + parameterTypes + " " + optionalParameterTypes);
+			il.EmitCalli(opcode, callingConvention, returnType, parameterTypes, optionalParameterTypes);
+		}
+
+		public static void EmitWriteLine(ILGenerator il, string value)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + "WriteLine " + FormatArgument(value));
+			il.EmitWriteLine(value);
+		}
+
+		public static void EmitWriteLine(ILGenerator il, LocalBuilder localBuilder)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + "WriteLine " + FormatArgument(localBuilder));
+			il.EmitWriteLine(localBuilder);
+		}
+
+		public static void EmitWriteLine(ILGenerator il, FieldInfo fld)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log(CodePos(il) + "WriteLine " + FormatArgument(fld));
+			il.EmitWriteLine(fld);
+		}
+
+	}
+}

--- a/ModLoader/Harmony/ILCopying/ILInstruction.cs
+++ b/ModLoader/Harmony/ILCopying/ILInstruction.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace Harmony.ILCopying
+{
+	public class ILInstruction
+	{
+		public int offset;
+		public OpCode opcode;
+		public object operand;
+		public object argument;
+
+		public List<Label> labels = new List<Label>();
+
+		public ILInstruction(OpCode opcode, object operand = null)
+		{
+			this.opcode = opcode;
+			this.operand = operand;
+			this.argument = operand;
+		}
+
+		public CodeInstruction GetCodeInstruction()
+		{
+			var instr = new CodeInstruction(opcode, argument);
+			if (opcode.OperandType == OperandType.InlineNone)
+				instr.operand = null;
+			instr.labels = labels;
+			return instr;
+		}
+
+		public int GetSize()
+		{
+			int size = opcode.Size;
+
+			switch (opcode.OperandType)
+			{
+				case OperandType.InlineSwitch:
+					size += (1 + ((int[])operand).Length) * 4;
+					break;
+
+				case OperandType.InlineI8:
+				case OperandType.InlineR:
+					size += 8;
+					break;
+
+				case OperandType.InlineBrTarget:
+				case OperandType.InlineField:
+				case OperandType.InlineI:
+				case OperandType.InlineMethod:
+				case OperandType.InlineString:
+				case OperandType.InlineTok:
+				case OperandType.InlineType:
+				case OperandType.ShortInlineR:
+					size += 4;
+					break;
+
+				case OperandType.InlineVar:
+					size += 2;
+					break;
+
+				case OperandType.ShortInlineBrTarget:
+				case OperandType.ShortInlineI:
+				case OperandType.ShortInlineVar:
+					size += 1;
+					break;
+			}
+
+			return size;
+		}
+
+		public override string ToString()
+		{
+			var instruction = "";
+
+			AppendLabel(ref instruction, this);
+			instruction = instruction + ": " + opcode.Name;
+
+			if (operand == null)
+				return instruction;
+
+			instruction = instruction + " ";
+
+			switch (opcode.OperandType)
+			{
+				case OperandType.ShortInlineBrTarget:
+				case OperandType.InlineBrTarget:
+					AppendLabel(ref instruction, operand);
+					break;
+
+				case OperandType.InlineSwitch:
+					var switchLabels = (ILInstruction[])operand;
+					for (int i = 0; i < switchLabels.Length; i++)
+					{
+						if (i > 0)
+							instruction = instruction + ",";
+
+						AppendLabel(ref instruction, switchLabels[i]);
+					}
+					break;
+
+				case OperandType.InlineString:
+					instruction = instruction + "\"" + operand + "\"";
+					break;
+
+				default:
+					instruction = instruction + operand;
+					break;
+			}
+
+			return instruction;
+		}
+
+		static void AppendLabel(ref string str, object argument)
+		{
+			var instruction = argument as ILInstruction;
+			if (instruction != null)
+				str = str + "IL_" + instruction.offset.ToString("X4");
+			else
+				str = str + "IL_" + argument;
+		}
+	}
+}

--- a/ModLoader/Harmony/ILCopying/Memory.cs
+++ b/ModLoader/Harmony/ILCopying/Memory.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Reflection;
+
+namespace Harmony.ILCopying
+{
+	public static class Memory
+	{
+		public static long WriteJump(long memory, long destination)
+		{
+			if (IntPtr.Size == sizeof(long))
+			{
+				memory = WriteBytes(memory, new byte[] { 0x48, 0xB8 });
+				memory = WriteLong(memory, destination);
+				memory = WriteBytes(memory, new byte[] { 0xFF, 0xE0 });
+			}
+			else
+			{
+				memory = WriteByte(memory, 0x68);
+				memory = WriteInt(memory, (int)destination);
+				memory = WriteByte(memory, 0xc3);
+			}
+			return memory;
+		}
+
+		public static long GetMethodStart(MethodBase method)
+		{
+			long originalCodeStart = 0;
+			if (MonoInternals.GetCodeInfo(method, out originalCodeStart) == false)
+				throw new Exception("Cannot get info for original: " + method);
+			return originalCodeStart;
+		}
+
+		public static unsafe long WriteByte(long memory, byte value)
+		{
+			var p = (byte*)memory;
+			*p = value;
+			return memory + sizeof(byte);
+		}
+
+		public static unsafe long WriteBytes(long memory, byte[] values)
+		{
+			foreach (var value in values)
+				memory = WriteByte(memory, value);
+			return memory;
+		}
+
+		public static unsafe long WriteInt(long memory, int value)
+		{
+			var p = (int*)memory;
+			*p = value;
+			return memory + sizeof(int);
+		}
+
+		public static unsafe long WriteLong(long memory, long value)
+		{
+			var p = (long*)memory;
+			*p = value;
+			return memory + sizeof(long);
+		}
+	}
+}

--- a/ModLoader/Harmony/ILCopying/MethodCopier.cs
+++ b/ModLoader/Harmony/ILCopying/MethodCopier.cs
@@ -1,0 +1,610 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace Harmony.ILCopying
+{
+	public class MethodCopier
+	{
+		readonly MethodBodyReader reader;
+		readonly List<MethodInfo> transpilers = new List<MethodInfo>();
+
+		public MethodCopier(MethodBase fromMethod, DynamicMethod toDynamicMethod, LocalBuilder[] existingVariables = null)
+		{
+			if (fromMethod == null) throw new Exception("method cannot be null");
+			var generator = toDynamicMethod.GetILGenerator();
+			reader = new MethodBodyReader(fromMethod, generator);
+			reader.DeclareVariables(existingVariables);
+			reader.ReadInstructions();
+		}
+
+		public void AddTranspiler(MethodInfo transpiler)
+		{
+			transpilers.Add(transpiler);
+		}
+
+		public void Emit(Label endLabel)
+		{
+			reader.FinalizeILCodes(transpilers, endLabel);
+		}
+	}
+
+	public class MethodBodyReader
+	{
+		readonly ILGenerator generator;
+
+		readonly MethodBase method;
+		readonly Module module;
+		readonly Type[] typeArguments;
+		readonly Type[] methodArguments;
+		readonly ByteBuffer ilBytes;
+		readonly ParameterInfo this_parameter;
+		readonly ParameterInfo[] parameters;
+		readonly IList<LocalVariableInfo> locals;
+		readonly IList<ExceptionHandlingClause> exceptions;
+		List<ILInstruction> ilInstructions;
+
+		LocalBuilder[] variables;
+
+		public static List<ILInstruction> GetInstructions(MethodBase method)
+		{
+			if (method == null) throw new Exception("method cannot be null");
+			var reader = new MethodBodyReader(method, null);
+			reader.ReadInstructions();
+			return reader.ilInstructions;
+		}
+
+		// constructor
+
+		public MethodBodyReader(MethodBase method, ILGenerator generator)
+		{
+			this.generator = generator;
+			this.method = method;
+			module = method.Module;
+
+			var body = method.GetMethodBody();
+			if (body == null)
+				throw new ArgumentException("Method has no body");
+
+			var bytes = body.GetILAsByteArray();
+			if (bytes == null)
+				throw new ArgumentException("Can not get the bytes of the method");
+			ilBytes = new ByteBuffer(bytes);
+			ilInstructions = new List<ILInstruction>((bytes.Length + 1) / 2);
+
+			Type type = method.DeclaringType;
+			if (type != null)
+			{
+				if (type.IsGenericType || type.IsGenericTypeDefinition)
+					typeArguments = type.GetGenericArguments();
+			}
+			if (method.IsGenericMethod || method.IsGenericMethodDefinition)
+				methodArguments = method.GetGenericArguments();
+
+			if (!method.IsStatic)
+				this_parameter = new ThisParameter(method);
+			parameters = method.GetParameters();
+
+			locals = body.LocalVariables;
+			exceptions = body.ExceptionHandlingClauses;
+		}
+
+		// read and parse IL codes
+
+		public void ReadInstructions()
+		{
+			while (ilBytes.position < ilBytes.buffer.Length)
+			{
+				var loc = ilBytes.position; // get location first (ReadOpCode will advance it)
+				var instruction = new ILInstruction(ReadOpCode());
+				instruction.offset = loc;
+				ReadOperand(instruction);
+				ilInstructions.Add(instruction);
+			}
+
+			ResolveBranches();
+		}
+
+		void ResolveBranches()
+		{
+			foreach (var instruction in ilInstructions)
+			{
+				switch (instruction.opcode.OperandType)
+				{
+					case OperandType.ShortInlineBrTarget:
+					case OperandType.InlineBrTarget:
+						instruction.operand = GetInstruction((int)instruction.operand);
+						break;
+
+					case OperandType.InlineSwitch:
+						var offsets = (int[])instruction.operand;
+						var branches = new ILInstruction[offsets.Length];
+						for (int j = 0; j < offsets.Length; j++)
+							branches[j] = GetInstruction(offsets[j]);
+
+						instruction.operand = branches;
+						break;
+				}
+			}
+		}
+
+		// declare local variables
+		public void DeclareVariables(LocalBuilder[] existingVariables)
+		{
+			if (generator == null) return;
+			if (existingVariables != null)
+				variables = existingVariables;
+			else
+				variables = locals.Select(
+					lvi => generator.DeclareLocal(lvi.LocalType, lvi.IsPinned)
+				).ToArray();
+		}
+
+		// use parsed IL codes and emit them to a generator
+
+		public void FinalizeILCodes(List<MethodInfo> transpilers, Label endLabel)
+		{
+			if (generator == null) return;
+
+			// pass1 - define labels and add them to instructions that are target of a jump
+			ilInstructions.ForEach(ilInstruction =>
+			{
+				switch (ilInstruction.opcode.OperandType)
+				{
+					case OperandType.InlineSwitch:
+						{
+							var targets = ilInstruction.operand as ILInstruction[];
+							if (targets != null)
+							{
+								var labels = new List<Label>();
+								foreach (var target in targets)
+								{
+									var label = generator.DefineLabel();
+									target.labels.Add(label);
+									labels.Add(label);
+								}
+								ilInstruction.argument = labels.ToArray();
+							}
+							break;
+						}
+
+					case OperandType.ShortInlineBrTarget:
+					case OperandType.InlineBrTarget:
+						{
+							var target = ilInstruction.operand as ILInstruction;
+							if (target != null)
+							{
+								var label = generator.DefineLabel();
+								target.labels.Add(label);
+								ilInstruction.argument = label;
+							}
+							break;
+						}
+				}
+			});
+
+			// pass2 - filter through all processors
+			var codeTranspiler = new CodeTranspiler(ilInstructions);
+			transpilers.ForEach(transpiler => codeTranspiler.Add(transpiler));
+			var codeInstructions = codeTranspiler.GetResult(generator, method)
+				.Select(instruction =>
+				{
+					// TODO - improve the logic here. for now, we replace all short jumps
+					//        with long jumps regardless of how far the jump is
+					//
+					new Dictionary<OpCode, OpCode>
+					{
+						{ OpCodes.Beq_S, OpCodes.Beq },
+						{ OpCodes.Bge_S, OpCodes.Bge },
+						{ OpCodes.Bge_Un_S, OpCodes.Bge_Un },
+						{ OpCodes.Bgt_S, OpCodes.Bgt },
+						{ OpCodes.Bgt_Un_S, OpCodes.Bgt_Un },
+						{ OpCodes.Ble_S, OpCodes.Ble },
+						{ OpCodes.Ble_Un_S, OpCodes.Ble_Un },
+						{ OpCodes.Blt_S, OpCodes.Blt },
+						{ OpCodes.Blt_Un_S, OpCodes.Blt_Un },
+						{ OpCodes.Bne_Un_S, OpCodes.Bne_Un },
+						{ OpCodes.Brfalse_S, OpCodes.Brfalse },
+						{ OpCodes.Brtrue_S, OpCodes.Brtrue },
+						{ OpCodes.Br_S, OpCodes.Br }
+					}.Do(pair =>
+					{
+						if (instruction.opcode == pair.Key)
+							instruction.opcode = pair.Value;
+					});
+
+					if (instruction.opcode == OpCodes.Ret)
+					{
+						instruction.opcode = OpCodes.Br;
+						instruction.operand = endLabel;
+					}
+					return instruction;
+				});
+
+			// pass3 - mark labels and emit codes
+			codeInstructions.Do(codeInstruction =>
+			{
+				codeInstruction.labels.ForEach(label => Emitter.MarkLabel(generator, label));
+
+				var code = codeInstruction.opcode;
+				var operand = codeInstruction.operand;
+
+				if (code.OperandType == OperandType.InlineNone)
+					Emitter.Emit(generator, code);
+				else
+				{
+					if (operand == null) throw new Exception("Wrong null argument: " + codeInstruction);
+					var emitMethod = EmitMethodForType(operand.GetType());
+					if (emitMethod == null) throw new Exception("Unknown Emit argument type " + operand.GetType() + " in " + codeInstruction);
+					if (HarmonyInstance.DEBUG) FileLog.Log(Emitter.CodePos(generator) + code + " " + Emitter.FormatArgument(operand));
+					emitMethod.Invoke(generator, new object[] { code, operand });
+				}
+			});
+		}
+
+		static void GetMemberInfoValue(MemberInfo info, out object result)
+		{
+			result = null;
+			switch (info.MemberType)
+			{
+				case MemberTypes.Constructor:
+					result = (ConstructorInfo)info;
+					break;
+
+				case MemberTypes.Event:
+					result = (EventInfo)info;
+					break;
+
+				case MemberTypes.Field:
+					result = (FieldInfo)info;
+					break;
+
+				case MemberTypes.Method:
+					result = (MethodInfo)info;
+					break;
+
+				case MemberTypes.TypeInfo:
+				case MemberTypes.NestedType:
+					result = (Type)info;
+					break;
+
+				case MemberTypes.Property:
+					result = (PropertyInfo)info;
+					break;
+			}
+		}
+
+		// interpret instruction operand
+
+		void ReadOperand(ILInstruction instruction)
+		{
+			switch (instruction.opcode.OperandType)
+			{
+				case OperandType.InlineNone:
+					{
+						instruction.argument = null;
+						break;
+					}
+
+				case OperandType.InlineSwitch:
+					{
+						var length = ilBytes.ReadInt32();
+						var base_offset = ilBytes.position + (4 * length);
+						var branches = new int[length];
+						for (int i = 0; i < length; i++)
+							branches[i] = ilBytes.ReadInt32() + base_offset;
+						instruction.operand = branches;
+						break;
+					}
+
+				case OperandType.ShortInlineBrTarget:
+					{
+						var val = (sbyte)ilBytes.ReadByte();
+						instruction.operand = val + ilBytes.position;
+						break;
+					}
+
+				case OperandType.InlineBrTarget:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = val + ilBytes.position;
+						break;
+					}
+
+				case OperandType.ShortInlineI:
+					{
+						if (instruction.opcode == OpCodes.Ldc_I4_S)
+						{
+							var sb = (sbyte)ilBytes.ReadByte();
+							instruction.operand = sb;
+							instruction.argument = (sbyte)instruction.operand;
+						}
+						else
+						{
+							var b = ilBytes.ReadByte();
+							instruction.operand = b;
+							instruction.argument = (byte)instruction.operand;
+						}
+						break;
+					}
+
+				case OperandType.InlineI:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = val;
+						instruction.argument = (int)instruction.operand;
+						break;
+					}
+
+				case OperandType.ShortInlineR:
+					{
+						var val = ilBytes.ReadSingle();
+						instruction.operand = val;
+						instruction.argument = (float)instruction.operand;
+						break;
+					}
+
+				case OperandType.InlineR:
+					{
+						var val = ilBytes.ReadDouble();
+						instruction.operand = val;
+						instruction.argument = (double)instruction.operand;
+						break;
+					}
+
+				case OperandType.InlineI8:
+					{
+						var val = ilBytes.ReadInt64();
+						instruction.operand = val;
+						instruction.argument = (long)instruction.operand;
+						break;
+					}
+
+				case OperandType.InlineSig:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = module.ResolveSignature(val);
+						instruction.argument = (SignatureHelper)instruction.operand;
+						break;
+					}
+
+				case OperandType.InlineString:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = module.ResolveString(val);
+						instruction.argument = (string)instruction.operand;
+						break;
+					}
+
+				case OperandType.InlineTok:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = module.ResolveMember(val, typeArguments, methodArguments);
+						GetMemberInfoValue((MemberInfo)instruction.operand, out instruction.argument);
+						break;
+					}
+
+				case OperandType.InlineType:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = module.ResolveType(val, typeArguments, methodArguments);
+						instruction.argument = (Type)instruction.operand;
+						break;
+					}
+
+				case OperandType.InlineMethod:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = module.ResolveMethod(val, typeArguments, methodArguments);
+						if (instruction.operand is ConstructorInfo)
+							instruction.argument = (ConstructorInfo)instruction.operand;
+						else
+							instruction.argument = (MethodInfo)instruction.operand;
+						break;
+					}
+
+				case OperandType.InlineField:
+					{
+						var val = ilBytes.ReadInt32();
+						instruction.operand = module.ResolveField(val, typeArguments, methodArguments);
+						instruction.argument = (FieldInfo)instruction.operand;
+						break;
+					}
+
+				case OperandType.ShortInlineVar:
+					{
+						var idx = ilBytes.ReadByte();
+						if (TargetsLocalVariable(instruction.opcode))
+						{
+							var lvi = GetLocalVariable(idx);
+							if (lvi == null)
+								instruction.argument = idx;
+							else
+							{
+								instruction.operand = lvi;
+								instruction.argument = variables[lvi.LocalIndex];
+							}
+						}
+						else
+						{
+							instruction.operand = GetParameter(idx);
+							instruction.argument = idx;
+						}
+						break;
+					}
+
+				case OperandType.InlineVar:
+					{
+						var idx = ilBytes.ReadInt16();
+						if (TargetsLocalVariable(instruction.opcode))
+						{
+							var lvi = GetLocalVariable(idx);
+							if (lvi == null)
+								instruction.argument = idx;
+							else
+							{
+								instruction.operand = lvi;
+								instruction.argument = variables[lvi.LocalIndex];
+							}
+						}
+						else
+						{
+							instruction.operand = GetParameter(idx);
+							instruction.argument = idx;
+						}
+						break;
+					}
+
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		// TODO - implement
+		void ParseExceptions()
+		{
+			foreach (var ehc in exceptions)
+			{
+				//Log.Error("ExceptionHandlingClause, flags " + ehc.Flags.ToString());
+
+				// The FilterOffset property is meaningful only for Filter
+				// clauses. The CatchType property is not meaningful for 
+				// Filter or Finally clauses. 
+				switch (ehc.Flags)
+				{
+					case ExceptionHandlingClauseOptions.Filter:
+						//Log.Error("    Filter Offset: " + ehc.FilterOffset);
+						break;
+					case ExceptionHandlingClauseOptions.Finally:
+						break;
+						//default:
+						//Log.Error("Type of exception: " + ehc.CatchType);
+						//break;
+				}
+
+				//Log.Error("   Handler Length: " + ehc.HandlerLength);
+				//Log.Error("   Handler Offset: " + ehc.HandlerOffset);
+				//Log.Error(" Try Block Length: " + ehc.TryLength);
+				//Log.Error(" Try Block Offset: " + ehc.TryOffset);
+			}
+		}
+
+		ILInstruction GetInstruction(int offset)
+		{
+			var lastInstructionIndex = ilInstructions.Count - 1;
+			if (offset < 0 || offset > ilInstructions[lastInstructionIndex].offset)
+				throw new Exception("Instruction offset " + offset + " is outside valid range 0 - " + ilInstructions[lastInstructionIndex].offset);
+
+			int min = 0;
+			int max = lastInstructionIndex;
+			while (min <= max)
+			{
+				int mid = min + ((max - min) / 2);
+				var instruction = ilInstructions[mid];
+				var instruction_offset = instruction.offset;
+
+				if (offset == instruction_offset)
+					return instruction;
+
+				if (offset < instruction_offset)
+					max = mid - 1;
+				else
+					min = mid + 1;
+			}
+
+			throw new Exception("Cannot find instruction for " + offset);
+		}
+
+		static bool TargetsLocalVariable(OpCode opcode)
+		{
+			return opcode.Name.Contains("loc");
+		}
+
+		LocalVariableInfo GetLocalVariable(int index)
+		{
+			return locals == null ? null : locals[index];
+		}
+
+		ParameterInfo GetParameter(int index)
+		{
+			if (index == 0)
+				return this_parameter;
+
+			return parameters[index - 1];
+		}
+
+		OpCode ReadOpCode()
+		{
+			var op = ilBytes.ReadByte();
+			return op != 0xfe
+				? one_byte_opcodes[op]
+				: two_bytes_opcodes[ilBytes.ReadByte()];
+		}
+
+		MethodInfo EmitMethodForType(Type type)
+		{
+			foreach (KeyValuePair<Type, MethodInfo> entry in emitMethods)
+				if (entry.Key == type) return entry.Value;
+			foreach (KeyValuePair<Type, MethodInfo> entry in emitMethods)
+				if (entry.Key.IsAssignableFrom(type)) return entry.Value;
+			return null;
+		}
+
+		// static initializer to prep opcodes
+
+		static readonly OpCode[] one_byte_opcodes;
+		static readonly OpCode[] two_bytes_opcodes;
+
+		static readonly Dictionary<Type, MethodInfo> emitMethods;
+
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		static MethodBodyReader()
+		{
+			one_byte_opcodes = new OpCode[0xe1];
+			two_bytes_opcodes = new OpCode[0x1f];
+
+			var fields = typeof(OpCodes).GetFields(
+				BindingFlags.Public | BindingFlags.Static);
+
+			foreach (var field in fields)
+			{
+				var opcode = (OpCode)field.GetValue(null);
+				if (opcode.OpCodeType == OpCodeType.Nternal)
+					continue;
+
+				if (opcode.Size == 1)
+					one_byte_opcodes[opcode.Value] = opcode;
+				else
+					two_bytes_opcodes[opcode.Value & 0xff] = opcode;
+			}
+
+			emitMethods = new Dictionary<Type, MethodInfo>();
+			typeof(ILGenerator).GetMethods().ToList()
+				.ForEach(method =>
+				{
+					if (method.Name != "Emit") return;
+					var pinfos = method.GetParameters();
+					if (pinfos.Length != 2) return;
+					var types = pinfos.Select(p => p.ParameterType).ToArray();
+					if (types[0] != typeof(OpCode)) return;
+					emitMethods[types[1]] = method;
+				});
+		}
+
+		// a custom this parameter
+
+		class ThisParameter : ParameterInfo
+		{
+			public ThisParameter(MethodBase method)
+			{
+				MemberImpl = method;
+				ClassImpl = method.DeclaringType;
+				NameImpl = "this";
+				PositionImpl = -1;
+			}
+		}
+	}
+}

--- a/ModLoader/Harmony/ILCopying/MonoInternals.cs
+++ b/ModLoader/Harmony/ILCopying/MonoInternals.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Harmony.ILCopying
+{
+	public static unsafe class MonoInternals
+	{
+		public static bool GetCodeInfo(MethodBase method, out long start)
+		{
+			start = 0;
+			var ptr = method.MethodHandle.GetFunctionPointer().ToPointer();
+			var mono_jit_info_ptr = mono_jit_info_table_find(mono_domain_get(), ptr);
+			if (mono_jit_info_ptr == null) return false;
+			start = mono_jit_info_ptr->code_start.ToInt64();
+			return true;
+		}
+
+		//
+
+#pragma warning disable CS0649
+		// void* equal to "native integer", it follows word size based on platform used automatically
+		public struct _MonoJitInfo
+		{
+			// should work on x64 due to variable size of void*
+			public RuntimeMethodHandle method; //should work properly because IntPtr host void* intenrnally
+			public void* next_jit_code_hash;
+			public IntPtr code_start; //same void* under wrappers
+			public uint unwind_info;
+			public int code_size;
+			public void* __rest_is_omitted;
+			// struct is longer actually, but rest of fields does not matter
+		}
+#pragma warning restore CS0649
+
+		[DllImport("__Internal", EntryPoint = "mono_domain_get")]
+		extern static private void* mono_domain_get__EXT();
+		[DllImport("mono.dll", EntryPoint = "mono_domain_get")]
+		extern static private void* mono_domain_get__W32();
+		[DllImport("libmono.so", EntryPoint = "mono_domain_get")]
+		extern static private void* mono_domain_get__M64();
+		[DllImport("libmono.so", EntryPoint = "mono_domain_get")]
+		extern static private void* mono_domain_get__L64();
+
+		[DllImport("__Internal", EntryPoint = "mono_jit_info_table_find")]
+		extern static private _MonoJitInfo* mono_jit_info_table_find__EXT(void* domain, void* function);
+		[DllImport("mono.dll", EntryPoint = "mono_jit_info_table_find")]
+		extern static private _MonoJitInfo* mono_jit_info_table_find__W32(void* domain, void* function);
+		[DllImport("libmono.so", EntryPoint = "mono_jit_info_table_find")]
+		extern static private _MonoJitInfo* mono_jit_info_table_find__M64(void* domain, void* function);
+		[DllImport("libmono.so", EntryPoint = "mono_jit_info_table_find")]
+		extern static private _MonoJitInfo* mono_jit_info_table_find__L64(void* domain, void* function);
+
+		public enum Platform
+		{
+			EXT, W32, M64, L64
+		}
+
+		static Platform CurrentPlatform
+		{
+			get
+			{
+				var cmdLine = Environment.CommandLine;
+				if (cmdLine != null && cmdLine.Length > 0)
+				{
+					var c = cmdLine.Substring(cmdLine.Length - 1);
+					switch (c)
+					{
+						case "e": // exe
+							return Platform.W32;
+						case "l": // dll
+							return Platform.EXT;
+						case "C": // mac
+							return Platform.M64;
+						case "4": // linux
+							return Platform.L64;
+					}
+				}
+
+				switch (Environment.OSVersion.Platform)
+				{
+					case PlatformID.Win32S:
+					case PlatformID.Win32Windows:
+					case PlatformID.Win32NT:
+					case PlatformID.WinCE:
+						return Platform.W32;
+					case PlatformID.MacOSX:
+						return Platform.M64;
+					case PlatformID.Unix:
+					case (PlatformID)128:
+						if (Directory.Exists("/Applications")
+						  & Directory.Exists("/System")
+						  & Directory.Exists("/Users")
+						  & Directory.Exists("/Volumes"))
+							return Platform.M64;
+						return Platform.L64;
+				}
+
+				throw new ArgumentOutOfRangeException("Unknown operating system (" + Environment.CommandLine + ") (" + Environment.OSVersion.Platform + ")");
+			}
+		}
+
+		static void* mono_domain_get()
+		{
+			if (CurrentPlatform == Platform.W32)
+				return mono_domain_get__W32();
+
+			if (CurrentPlatform == Platform.EXT)
+				return mono_domain_get__EXT();
+
+			if (CurrentPlatform == Platform.M64)
+				return mono_domain_get__M64();
+
+			if (CurrentPlatform == Platform.L64)
+				return mono_domain_get__L64();
+
+			return null;
+		}
+
+		static _MonoJitInfo* mono_jit_info_table_find(void* domain, void* function)
+		{
+			if (CurrentPlatform == Platform.W32)
+				return mono_jit_info_table_find__W32(domain, function);
+
+			if (CurrentPlatform == Platform.EXT)
+				return mono_jit_info_table_find__EXT(domain, function);
+
+			if (CurrentPlatform == Platform.M64)
+				return mono_jit_info_table_find__M64(domain, function);
+
+			if (CurrentPlatform == Platform.L64)
+				return mono_jit_info_table_find__L64(domain, function);
+
+			return null;
+		}
+	}
+}

--- a/ModLoader/Harmony/MethodPatcher.cs
+++ b/ModLoader/Harmony/MethodPatcher.cs
@@ -1,0 +1,193 @@
+﻿using Harmony.ILCopying;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	public static class MethodPatcher
+	{
+		// special parameter names that can be used in prefix and postfix methods
+		//
+		public static string INSTANCE_PARAM = "__instance";
+		public static string RESULT_VAR = "__result";
+		public static string STATE_VAR = "__state";
+
+		public static DynamicMethod CreatePatchedMethod(MethodBase original, List<MethodInfo> prefixes, List<MethodInfo> postfixes, List<MethodInfo> transpilers)
+		{
+			if (HarmonyInstance.DEBUG) FileLog.Log("PATCHING " + original.DeclaringType + " " + original);
+
+			var idx = prefixes.Count() + postfixes.Count();
+			var patch = DynamicTools.CreateDynamicMethod(original, "_Patch" + idx);
+			var il = patch.GetILGenerator();
+
+			var originalVariables = DynamicTools.DeclareLocalVariables(original, il);
+			var privateVars = new Dictionary<string, LocalBuilder>();
+
+			LocalBuilder resultVariable = null;
+			if (idx > 0)
+			{
+				resultVariable = DynamicTools.DeclareLocalVariable(il, AccessTools.GetReturnedType(original));
+				privateVars[RESULT_VAR] = resultVariable;
+			}
+
+			prefixes.ForEach(prefix =>
+			{
+				prefix.GetParameters()
+					.Where(patchParam => patchParam.Name == STATE_VAR)
+					.Do(patchParam =>
+					{
+						var privateStateVariable = DynamicTools.DeclareLocalVariable(il, patchParam.ParameterType);
+						privateVars[prefix.DeclaringType.FullName] = privateStateVariable;
+					});
+			});
+
+			var afterOriginal1 = il.DefineLabel();
+			var afterOriginal2 = il.DefineLabel();
+			var canHaveJump = AddPrefixes(il, original, prefixes, privateVars, afterOriginal2);
+
+			var copier = new MethodCopier(original, patch, originalVariables);
+			foreach (var transpiler in transpilers)
+				copier.AddTranspiler(transpiler);
+			copier.Emit(afterOriginal1);
+			Emitter.MarkLabel(il, afterOriginal1);
+			if (resultVariable != null)
+				Emitter.Emit(il, OpCodes.Stloc, resultVariable);
+			if (canHaveJump)
+				Emitter.MarkLabel(il, afterOriginal2);
+
+			AddPostfixes(il, original, postfixes, privateVars);
+
+			if (resultVariable != null)
+				Emitter.Emit(il, OpCodes.Ldloc, resultVariable);
+			Emitter.Emit(il, OpCodes.Ret);
+
+			if (HarmonyInstance.DEBUG)
+			{
+				FileLog.Log("DONE");
+				FileLog.Log("");
+			}
+
+			DynamicTools.PrepareDynamicMethod(patch);
+			return patch;
+		}
+
+		static OpCode LoadIndOpCodeFor(Type type)
+		{
+			if (type.IsEnum) return OpCodes.Ldind_I4;
+
+			if (type == typeof(float)) return OpCodes.Ldind_R4;
+			if (type == typeof(double)) return OpCodes.Ldind_R8;
+
+			if (type == typeof(byte)) return OpCodes.Ldind_U1;
+			if (type == typeof(ushort)) return OpCodes.Ldind_U2;
+			if (type == typeof(uint)) return OpCodes.Ldind_U4;
+			if (type == typeof(ulong)) return OpCodes.Ldind_I8;
+
+			if (type == typeof(sbyte)) return OpCodes.Ldind_I1;
+			if (type == typeof(short)) return OpCodes.Ldind_I2;
+			if (type == typeof(int)) return OpCodes.Ldind_I4;
+			if (type == typeof(long)) return OpCodes.Ldind_I8;
+
+			return OpCodes.Ldind_Ref;
+		}
+
+		static void EmitCallParameter(ILGenerator il, MethodBase original, MethodInfo patch, Dictionary<string, LocalBuilder> variables)
+		{
+			var isInstance = original.IsStatic == false;
+			var originalParameters = original.GetParameters();
+			var originalParameterNames = originalParameters.Select(p => p.Name).ToArray();
+			foreach (var patchParam in patch.GetParameters())
+			{
+				if (patchParam.Name == INSTANCE_PARAM)
+				{
+					if (!isInstance) throw new Exception("Cannot get instance from static method " + original);
+					if (patchParam.ParameterType.IsByRef)
+						Emitter.Emit(il, OpCodes.Ldarga, 0); // probably won't work or will be useless
+					else
+						Emitter.Emit(il, OpCodes.Ldarg_0);
+					continue;
+				}
+
+				if (patchParam.Name == STATE_VAR)
+				{
+					var ldlocCode = patchParam.ParameterType.IsByRef ? OpCodes.Ldloca : OpCodes.Ldloc;
+					Emitter.Emit(il, ldlocCode, variables[patch.DeclaringType.FullName]);
+					continue;
+				}
+
+				if (patchParam.Name == RESULT_VAR)
+				{
+					if (AccessTools.GetReturnedType(original) == typeof(void))
+						throw new Exception("Cannot get result from void method " + original);
+					var ldlocCode = patchParam.ParameterType.IsByRef ? OpCodes.Ldloca : OpCodes.Ldloc;
+					Emitter.Emit(il, ldlocCode, variables[RESULT_VAR]);
+					continue;
+				}
+
+				var idx = Array.IndexOf(originalParameterNames, patchParam.Name);
+				if (idx == -1) throw new Exception("Parameter \"" + patchParam.Name + "\" not found in method " + original);
+
+				//   original -> patch     opcode
+				// --------------------------------------
+				// 1 normal   -> normal  : LDARG
+				// 2 normal   -> ref/out : LDARGA
+				// 3 ref/out  -> normal  : LDARG, LDIND_x
+				// 4 ref/out  -> ref/out : LDARG
+				//
+				var originalIsNormal = originalParameters[idx].IsOut == false && originalParameters[idx].ParameterType.IsByRef == false;
+				var patchIsNormal = patchParam.IsOut == false && patchParam.ParameterType.IsByRef == false;
+				var patchArgIndex = idx + (isInstance ? 1 : 0);
+
+				// Case 1 + 4
+				if (originalIsNormal == patchIsNormal)
+				{
+					Emitter.Emit(il, OpCodes.Ldarg, patchArgIndex);
+					continue;
+				}
+
+				// Case 2
+				if (originalIsNormal && patchIsNormal == false)
+				{
+					Emitter.Emit(il, OpCodes.Ldarga, patchArgIndex);
+					continue;
+				}
+
+				// Case 3
+				Emitter.Emit(il, OpCodes.Ldarg, patchArgIndex);
+				Emitter.Emit(il, LoadIndOpCodeFor(originalParameters[idx].ParameterType));
+			}
+		}
+
+		static bool AddPrefixes(ILGenerator il, MethodBase original, List<MethodInfo> prefixes, Dictionary<string, LocalBuilder> variables, Label label)
+		{
+			var canHaveJump = false;
+			prefixes.ForEach(fix =>
+			{
+				EmitCallParameter(il, original, fix, variables);
+				Emitter.Emit(il, OpCodes.Call, fix);
+				if (fix.ReturnType != typeof(void))
+				{
+					if (fix.ReturnType != typeof(bool))
+						throw new Exception("Prefix patch " + fix + " has not \"bool\" or \"void\" return type: " + fix.ReturnType);
+					Emitter.Emit(il, OpCodes.Brfalse, label);
+					canHaveJump = true;
+				}
+			});
+			return canHaveJump;
+		}
+
+		static void AddPostfixes(ILGenerator il, MethodBase original, List<MethodInfo> postfixes, Dictionary<string, LocalBuilder> variables)
+		{
+			postfixes.ForEach(fix =>
+			{
+				EmitCallParameter(il, original, fix, variables);
+				Emitter.Emit(il, OpCodes.Call, fix);
+				if (fix.ReturnType != typeof(void))
+					throw new Exception("Postfix patch " + fix + " has not \"void\" return type: " + fix.ReturnType);
+			});
+		}
+	}
+}

--- a/ModLoader/Harmony/Patch.cs
+++ b/ModLoader/Harmony/Patch.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Harmony
+{
+	public static class PatchInfoSerialization
+	{
+		class Binder : SerializationBinder
+		{
+			public override Type BindToType(string assemblyName, string typeName)
+			{
+				var types = new Type[] {
+					typeof(PatchInfo),
+					typeof(Patch[]),
+					typeof(Patch)
+				};
+				foreach (var type in types)
+					if (typeName == type.FullName)
+						return type;
+				var typeToDeserialize = Type.GetType(string.Format("{0}, {1}", typeName, assemblyName));
+				return typeToDeserialize;
+			}
+		}
+
+		public static byte[] Serialize(this PatchInfo patchInfo)
+		{
+#pragma warning disable XS0001
+			using (var streamMemory = new MemoryStream())
+			{
+				var formatter = new BinaryFormatter();
+				formatter.Serialize(streamMemory, patchInfo);
+				return streamMemory.GetBuffer();
+			}
+#pragma warning restore XS0001
+		}
+
+		public static PatchInfo Deserialize(byte[] bytes)
+		{
+			var formatter = new BinaryFormatter();
+			formatter.Binder = new Binder();
+#pragma warning disable XS0001
+			var streamMemory = new MemoryStream(bytes);
+#pragma warning restore XS0001
+			return (PatchInfo)formatter.Deserialize(streamMemory);
+		}
+
+		// general sorting by (in that order): before, after, priority and index
+		public static int PriorityComparer(object obj, int index, int priority, string[] before, string[] after)
+		{
+			var trv = Traverse.Create(obj);
+			var theirOwner = trv.Field("owner").GetValue<string>();
+			var theirPriority = trv.Field("priority").GetValue<int>();
+			var theirIndex = trv.Field("index").GetValue<int>();
+
+			if (before != null && Array.IndexOf(before, theirOwner) > -1)
+				return -1;
+			if (after != null && Array.IndexOf(after, theirOwner) > -1)
+				return 1;
+
+			if (priority != theirPriority)
+				return -(priority.CompareTo(theirPriority));
+
+			return index.CompareTo(theirIndex);
+		}
+	}
+
+	[Serializable]
+	public class PatchInfo
+	{
+		public Patch[] prefixes;
+		public Patch[] postfixes;
+		public Patch[] transpilers;
+
+		public PatchInfo()
+		{
+			prefixes = new Patch[0];
+			postfixes = new Patch[0];
+			transpilers = new Patch[0];
+		}
+
+		public void AddPrefix(MethodInfo patch, string owner, int priority, string[] before, string[] after)
+		{
+			var l = prefixes.ToList();
+			l.Add(new Patch(patch, prefixes.Count() + 1, owner, priority, before, after));
+			prefixes = l.ToArray();
+		}
+
+		public void AddPostfix(MethodInfo patch, string owner, int priority, string[] before, string[] after)
+		{
+			var l = postfixes.ToList();
+			l.Add(new Patch(patch, postfixes.Count() + 1, owner, priority, before, after));
+			postfixes = l.ToArray();
+		}
+
+		public void AddTranspiler(MethodInfo patch, string owner, int priority, string[] before, string[] after)
+		{
+			var l = transpilers.ToList();
+			l.Add(new Patch(patch, transpilers.Count() + 1, owner, priority, before, after));
+			transpilers = l.ToArray();
+		}
+	}
+
+	[Serializable]
+	public class Patch : IComparable
+	{
+		readonly public int index;
+		readonly public string owner;
+		readonly public int priority;
+		readonly public string[] before;
+		readonly public string[] after;
+
+		readonly public MethodInfo patch;
+
+		public Patch(MethodInfo patch, int index, string owner, int priority, string[] before, string[] after)
+		{
+			if (patch is DynamicMethod) throw new Exception("Cannot directly reference dynamic method \"" + patch + "\" in Harmony. Use a factory method instead that will return the dynamic method.");
+
+			this.index = index;
+			this.owner = owner;
+			this.priority = priority;
+			this.before = before;
+			this.after = after;
+			this.patch = patch;
+		}
+
+		public MethodInfo GetMethod(MethodBase original)
+		{
+			if (patch.ReturnType != typeof(DynamicMethod)) return patch;
+			if (patch.IsStatic == false) return patch;
+			var parameters = patch.GetParameters();
+			if (parameters.Count() != 1) return patch;
+			if (parameters[0].ParameterType != typeof(MethodBase)) return patch;
+
+			// we have a DynamicMethod factory, let's use it
+			return patch.Invoke(null, new object[] { original }) as DynamicMethod;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return ((obj != null) && (obj is Patch) && (patch == ((Patch)obj).patch));
+		}
+
+		public int CompareTo(object obj)
+		{
+			return PatchInfoSerialization.PriorityComparer(obj, index, priority, before, after);
+		}
+
+		public override int GetHashCode()
+		{
+			return patch.GetHashCode();
+		}
+	}
+}

--- a/ModLoader/Harmony/PatchFunctions.cs
+++ b/ModLoader/Harmony/PatchFunctions.cs
@@ -1,0 +1,69 @@
+﻿using Harmony.ILCopying;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Harmony
+{
+	public static class PatchFunctions
+	{
+		public static void AddPrefix(PatchInfo patchInfo, string owner, HarmonyMethod info)
+		{
+			if (info == null || info.method == null) return;
+
+			var priority = info.prioritiy == -1 ? Priority.Normal : info.prioritiy;
+			var before = info.before ?? new string[0];
+			var after = info.after ?? new string[0];
+
+			patchInfo.AddPrefix(info.method, owner, priority, before, after);
+		}
+
+		public static void AddPostfix(PatchInfo patchInfo, string owner, HarmonyMethod info)
+		{
+			if (info == null || info.method == null) return;
+
+			var priority = info.prioritiy == -1 ? Priority.Normal : info.prioritiy;
+			var before = info.before ?? new string[0];
+			var after = info.after ?? new string[0];
+
+			patchInfo.AddPostfix(info.method, owner, priority, before, after);
+		}
+
+		public static void AddTranspiler(PatchInfo patchInfo, string owner, HarmonyMethod info)
+		{
+			if (info == null || info.method == null) return;
+
+			var priority = info.prioritiy == -1 ? Priority.Normal : info.prioritiy;
+			var before = info.before ?? new string[0];
+			var after = info.after ?? new string[0];
+
+			patchInfo.AddTranspiler(info.method, owner, priority, before, after);
+		}
+
+		public static List<MethodInfo> GetSortedPatchMethods(MethodBase original, Patch[] patches)
+		{
+			return patches
+				.Where(p => p.patch != null)
+				.OrderBy(p => p)
+				.Select(p => p.GetMethod(original))
+				.ToList();
+		}
+
+		public static void UpdateWrapper(MethodBase original, PatchInfo patchInfo)
+		{
+			var sortedPrefixes = GetSortedPatchMethods(original, patchInfo.prefixes);
+			var sortedPostfixes = GetSortedPatchMethods(original, patchInfo.postfixes);
+			var sortedTranspilers = GetSortedPatchMethods(original, patchInfo.transpilers);
+
+			var replacement = MethodPatcher.CreatePatchedMethod(original, sortedPrefixes, sortedPostfixes, sortedTranspilers);
+			if (replacement == null) throw new MissingMethodException("Cannot create dynamic replacement for " + original);
+
+			var originalCodeStart = Memory.GetMethodStart(original);
+			var patchCodeStart = Memory.GetMethodStart(replacement);
+			Memory.WriteJump(originalCodeStart, patchCodeStart);
+
+			PatchTools.RememberObject(original, replacement); // no gc for new value + release old value to gc
+		}
+	}
+}

--- a/ModLoader/Harmony/PatchProcessor.cs
+++ b/ModLoader/Harmony/PatchProcessor.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Harmony
+{
+	public class PatchProcessor
+	{
+		static object locker = new object();
+
+		readonly HarmonyInstance instance;
+
+		readonly Type container;
+		readonly HarmonyMethod containerAttributes;
+
+		MethodBase original;
+		HarmonyMethod prefix;
+		HarmonyMethod postfix;
+		HarmonyMethod transpiler;
+
+		public PatchProcessor(HarmonyInstance instance, Type type, HarmonyMethod attributes)
+		{
+			this.instance = instance;
+			container = type;
+			containerAttributes = attributes ?? new HarmonyMethod(null);
+			prefix = containerAttributes.Clone();
+			postfix = containerAttributes.Clone();
+			transpiler = containerAttributes.Clone();
+			ProcessType();
+		}
+
+		public PatchProcessor(HarmonyInstance instance, MethodBase original, HarmonyMethod prefix, HarmonyMethod postfix, HarmonyMethod transpiler)
+		{
+			this.instance = instance;
+			this.original = original;
+			this.prefix = prefix ?? new HarmonyMethod(null);
+			this.postfix = postfix ?? new HarmonyMethod(null);
+			this.transpiler = transpiler ?? new HarmonyMethod(null);
+		}
+
+		public static Patches IsPatched(MethodBase method)
+		{
+			var patchInfo = HarmonySharedState.GetPatchInfo(method);
+			if (patchInfo == null) return null;
+			return new Patches(patchInfo.prefixes, patchInfo.postfixes);
+		}
+
+		public void Patch()
+		{
+			lock (locker)
+			{
+				var patchInfo = HarmonySharedState.GetPatchInfo(original);
+				if (patchInfo == null) patchInfo = new PatchInfo();
+
+				PatchFunctions.AddPrefix(patchInfo, instance.Id, prefix);
+				PatchFunctions.AddPostfix(patchInfo, instance.Id, postfix);
+				PatchFunctions.AddTranspiler(patchInfo, instance.Id, transpiler);
+				PatchFunctions.UpdateWrapper(original, patchInfo);
+
+				HarmonySharedState.UpdatePatchInfo(original, patchInfo);
+			}
+		}
+
+		bool CallPrepare()
+		{
+			if (original != null)
+				return RunMethod<HarmonyPrepare, bool>(true, original);
+			return RunMethod<HarmonyPrepare, bool>(true);
+		}
+
+		void ProcessType()
+		{
+			original = GetOriginalMethod();
+
+			var patchable = CallPrepare();
+			if (patchable)
+			{
+				if (original == null)
+					original = RunMethod<HarmonyTargetMethod, MethodBase>(null);
+				if (original == null)
+					throw new ArgumentException("No target method specified for class " + container.FullName);
+
+				PatchTools.GetPatches(container, original, out prefix.method, out postfix.method, out transpiler.method);
+
+				if (prefix.method != null)
+				{
+					if (prefix.method.IsStatic == false)
+						throw new ArgumentException("Patch method " + prefix.method.Name + " in " + prefix.method.DeclaringType + " must be static");
+
+					var prefixAttributes = prefix.method.GetHarmonyMethods();
+					containerAttributes.Merge(HarmonyMethod.Merge(prefixAttributes)).CopyTo(prefix);
+				}
+
+				if (postfix.method != null)
+				{
+					if (postfix.method.IsStatic == false)
+						throw new ArgumentException("Patch method " + postfix.method.Name + " in " + postfix.method.DeclaringType + " must be static");
+
+					var postfixAttributes = postfix.method.GetHarmonyMethods();
+					containerAttributes.Merge(HarmonyMethod.Merge(postfixAttributes)).CopyTo(postfix);
+				}
+
+				if (transpiler.method != null)
+				{
+					if (transpiler.method.IsStatic == false)
+						throw new ArgumentException("Patch method " + transpiler.method.Name + " in " + transpiler.method.DeclaringType + " must be static");
+
+					var infixAttributes = transpiler.method.GetHarmonyMethods();
+					containerAttributes.Merge(HarmonyMethod.Merge(infixAttributes)).CopyTo(transpiler);
+				}
+			}
+		}
+
+		MethodBase GetOriginalMethod()
+		{
+			var attr = containerAttributes;
+			if (attr.originalType == null) return null;
+			if (attr.methodName == null)
+				return AccessTools.Constructor(attr.originalType, attr.parameter);
+			return AccessTools.Method(attr.originalType, attr.methodName, attr.parameter);
+		}
+
+		T RunMethod<S, T>(T defaultIfNotExisting, params object[] parameters)
+		{
+			var methodName = typeof(S).Name.Replace("Harmony", "");
+
+			var paramList = new List<object> { instance };
+			paramList.AddRange(parameters);
+			var paramTypes = AccessTools.GetTypes(paramList.ToArray());
+			var method = PatchTools.GetPatchMethod<S>(container, methodName, paramTypes);
+			if (method != null && typeof(T).IsAssignableFrom(method.ReturnType))
+				return (T)method.Invoke(null, paramList.ToArray());
+
+			method = PatchTools.GetPatchMethod<S>(container, methodName, new Type[] { typeof(HarmonyInstance) });
+			if (method != null && typeof(T).IsAssignableFrom(method.ReturnType))
+				return (T)method.Invoke(null, new object[] { instance });
+
+			method = PatchTools.GetPatchMethod<S>(container, methodName, Type.EmptyTypes);
+			if (method != null)
+			{
+				if (typeof(T).IsAssignableFrom(method.ReturnType))
+					return (T)method.Invoke(null, Type.EmptyTypes);
+
+				method.Invoke(null, Type.EmptyTypes);
+				return defaultIfNotExisting;
+			}
+
+			return defaultIfNotExisting;
+		}
+	}
+}

--- a/ModLoader/Harmony/Priority.cs
+++ b/ModLoader/Harmony/Priority.cs
@@ -1,0 +1,15 @@
+﻿namespace Harmony
+{
+	public static class Priority
+	{
+		public const int Last = 0;
+		public const int VeryLow = 100;
+		public const int Low = 200;
+		public const int LowerThanNormal = 300;
+		public const int Normal = 400;
+		public const int HigherThanNormal = 500;
+		public const int High = 600;
+		public const int VeryHigh = 700;
+		public const int First = 800;
+	}
+}

--- a/ModLoader/Harmony/Tools/AccessCache.cs
+++ b/ModLoader/Harmony/Tools/AccessCache.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Harmony
+{
+	public class AccessCache
+	{
+		Dictionary<Type, Dictionary<string, FieldInfo>> fields = new Dictionary<Type, Dictionary<string, FieldInfo>>();
+		Dictionary<Type, Dictionary<string, PropertyInfo>> properties = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
+		readonly Dictionary<Type, Dictionary<string, Dictionary<Type[], MethodBase>>> methods = new Dictionary<Type, Dictionary<string, Dictionary<Type[], MethodBase>>>();
+
+		public FieldInfo GetFieldInfo(Type type, string name)
+		{
+			Dictionary<string, FieldInfo> fieldsByType = null;
+			fields.TryGetValue(type, out fieldsByType);
+			if (fieldsByType == null)
+			{
+				fieldsByType = new Dictionary<string, FieldInfo>();
+				fields.Add(type, fieldsByType);
+			}
+
+			FieldInfo field = null;
+			fieldsByType.TryGetValue(name, out field);
+			if (field == null)
+			{
+				field = AccessTools.Field(type, name);
+				fieldsByType.Add(name, field);
+			}
+			return field;
+		}
+
+		public PropertyInfo GetPropertyInfo(Type type, string name)
+		{
+			Dictionary<string, PropertyInfo> propertiesByType = null;
+			properties.TryGetValue(type, out propertiesByType);
+			if (propertiesByType == null)
+			{
+				propertiesByType = new Dictionary<string, PropertyInfo>();
+				properties.Add(type, propertiesByType);
+			}
+
+			PropertyInfo property = null;
+			propertiesByType.TryGetValue(name, out property);
+			if (property == null)
+			{
+				property = AccessTools.Property(type, name);
+				propertiesByType.Add(name, property);
+			}
+			return property;
+		}
+
+		public MethodBase GetMethodInfo(Type type, string name, Type[] arguments)
+		{
+			Dictionary<string, Dictionary<Type[], MethodBase>> methodsByName = null;
+			methods.TryGetValue(type, out methodsByName);
+			if (methodsByName == null)
+			{
+				methodsByName = new Dictionary<string, Dictionary<Type[], MethodBase>>();
+				methods.Add(type, methodsByName);
+			}
+
+			Dictionary<Type[], MethodBase> methodsByArguments = null;
+			methodsByName.TryGetValue(name, out methodsByArguments);
+			if (methodsByArguments == null)
+			{
+				methodsByArguments = new Dictionary<Type[], MethodBase>();
+				methodsByName.Add(name, methodsByArguments);
+			}
+
+			MethodBase method = null;
+			methodsByArguments.TryGetValue(arguments, out method);
+			if (method == null)
+			{
+				method = AccessTools.Method(type, name, arguments);
+				methodsByArguments.Add(arguments, method);
+			}
+
+			return method;
+		}
+	}
+}

--- a/ModLoader/Harmony/Tools/AccessTools.cs
+++ b/ModLoader/Harmony/Tools/AccessTools.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Harmony
+{
+	public static class AccessTools
+	{
+		public static BindingFlags all = BindingFlags.Public
+			| BindingFlags.NonPublic
+			| BindingFlags.Instance
+			| BindingFlags.Static
+			| BindingFlags.GetField
+			| BindingFlags.SetField
+			| BindingFlags.GetProperty
+			| BindingFlags.SetProperty;
+
+		public static Type TypeByName(string name)
+		{
+			var type = Type.GetType(name, false);
+			if (type == null)
+				type = AppDomain.CurrentDomain.GetAssemblies()
+					.SelectMany(x => x.GetTypes())
+					.FirstOrDefault(x => x.FullName == name);
+			if (type == null)
+				type = AppDomain.CurrentDomain.GetAssemblies()
+					.SelectMany(x => x.GetTypes())
+					.FirstOrDefault(x => x.Name == name);
+			return type;
+		}
+
+		public static T FindRecursive<T>(Type type, Func<Type, T> action)
+		{
+			while (true)
+			{
+				var result = action(type);
+				if (result != null) return result;
+				if (type == typeof(object)) return default(T);
+				type = type.BaseType;
+			}
+		}
+
+		public static FieldInfo Field(Type type, string name)
+		{
+			if (type == null || name == null) return null;
+			return FindRecursive(type, t => t.GetField(name, all));
+		}
+
+		public static PropertyInfo Property(Type type, string name)
+		{
+			if (type == null || name == null) return null;
+			return FindRecursive(type, t => t.GetProperty(name, all));
+		}
+
+		public static MethodInfo Method(Type type, string name, Type[] parameters = null, Type[] generics = null)
+		{
+			if (type == null || name == null) return null;
+			MethodInfo result;
+			if (parameters == null)
+				result = FindRecursive(type, t => t.GetMethod(name, all));
+			else
+			{
+				var modifiers = new ParameterModifier[] { };
+				result = FindRecursive(type, t => t.GetMethod(name, all, null, parameters, modifiers));
+			}
+			if (result == null) return null;
+			if (generics != null) result = result.MakeGenericMethod(generics);
+			return result;
+		}
+
+		public static ConstructorInfo Constructor(Type type, Type[] parameters = null)
+		{
+			if (type == null) return null;
+			if (parameters == null) parameters = new Type[0];
+			return FindRecursive(type, t => t.GetConstructor(all, null, parameters, new ParameterModifier[] { }));
+		}
+
+		public static Type GetReturnedType(MethodBase method)
+		{
+			var constructor = method as ConstructorInfo;
+			if (constructor != null) return typeof(void);
+			return ((MethodInfo)method).ReturnType;
+		}
+
+		public static Type Inner(Type type, string name)
+		{
+			if (type == null || name == null) return null;
+			return FindRecursive(type, t => t.GetNestedType(name, all));
+		}
+
+		public static Type FirstInner(Type type, Func<Type, bool> predicate)
+		{
+			if (type == null || predicate == null) return null;
+			return FindRecursive(type, t => t.GetNestedTypes(all).First(predicate));
+		}
+
+		public static Type[] GetTypes(object[] parameters)
+		{
+			if (parameters == null) return new Type[0];
+			return parameters.Select(p => p == null ? typeof(object) : p.GetType()).ToArray();
+		}
+
+		public static List<string> GetFieldNames(Type type)
+		{
+			return type.GetFields(all).Select(f => f.Name).ToList();
+		}
+
+		public static List<string> GetFieldNames(object instance)
+		{
+			if (instance == null) return new List<string>();
+			return GetFieldNames(instance.GetType());
+		}
+
+		public static List<string> GetPropertyNames(Type type)
+		{
+			return type.GetProperties(all).Select(f => f.Name).ToList();
+		}
+
+		public static List<string> GetPropertyNames(object instance)
+		{
+			if (instance == null) return new List<string>();
+			return GetPropertyNames(instance.GetType());
+		}
+
+		public static object GetDefaultValue(Type type)
+		{
+			if (type == null) return null;
+			if (type == typeof(void)) return null;
+			if (type.IsValueType)
+				return Activator.CreateInstance(type);
+			return null;
+		}
+
+		public static bool isStruct(Type type)
+		{
+			return type.IsValueType && !isValue(type) && !isVoid(type);
+		}
+
+		public static bool isClass(Type type)
+		{
+			return !type.IsValueType;
+		}
+
+		public static bool isValue(Type type)
+		{
+			return type.IsPrimitive || type.IsEnum;
+		}
+
+		public static bool isVoid(Type type)
+		{
+			return type == typeof(void);
+		}
+	}
+}

--- a/ModLoader/Harmony/Tools/DynamicTools.cs
+++ b/ModLoader/Harmony/Tools/DynamicTools.cs
@@ -1,0 +1,93 @@
+﻿using Harmony.ILCopying;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	public static class DynamicTools
+	{
+		public static DynamicMethod CreateDynamicMethod(MethodBase original, string suffix)
+		{
+			if (original == null) throw new Exception("original cannot be null");
+			var patchName = original.Name + suffix;
+			patchName = patchName.Replace("<>", "");
+
+			var parameters = original.GetParameters();
+			var result = parameters.Types().ToList();
+			if (original.IsStatic == false)
+				result.Insert(0, typeof(object));
+			var paramTypes = result.ToArray();
+
+			var method = new DynamicMethod(
+				patchName,
+				MethodAttributes.Public | (original.IsStatic ? MethodAttributes.Static : 0),
+				CallingConventions.Standard,
+				AccessTools.GetReturnedType(original),
+				paramTypes,
+				original.DeclaringType,
+				true
+			);
+
+			for (int i = 0; i < parameters.Length; i++)
+				method.DefineParameter(i + 1, parameters[i].Attributes, parameters[i].Name);
+
+			return method;
+		}
+
+		public static LocalBuilder[] DeclareLocalVariables(MethodBase original, ILGenerator il)
+		{
+			return original.GetMethodBody().LocalVariables.Select(lvi =>
+			{
+				var localBuilder = il.DeclareLocal(lvi.LocalType, lvi.IsPinned);
+				Emitter.LogLastLocalVariable(il);
+				return localBuilder;
+			}).ToArray();
+		}
+
+		public static LocalBuilder DeclareLocalVariable(ILGenerator il, Type type)
+		{
+			if (type.IsByRef) type = type.GetElementType();
+
+			if (AccessTools.isClass(type))
+			{
+				var v = il.DeclareLocal(type);
+				Emitter.LogLastLocalVariable(il);
+				Emitter.Emit(il, OpCodes.Ldnull);
+				Emitter.Emit(il, OpCodes.Stloc, v);
+				return v;
+			}
+			if (AccessTools.isStruct(type))
+			{
+				var v = il.DeclareLocal(type);
+				Emitter.LogLastLocalVariable(il);
+				Emitter.Emit(il, OpCodes.Ldloca, v);
+				Emitter.Emit(il, OpCodes.Initobj, type);
+				return v;
+			}
+			if (AccessTools.isValue(type))
+			{
+				var v = il.DeclareLocal(type);
+				Emitter.LogLastLocalVariable(il);
+				if (type == typeof(float))
+					Emitter.Emit(il, OpCodes.Ldc_R4, (float)0);
+				else if (type == typeof(double))
+					Emitter.Emit(il, OpCodes.Ldc_R8, (double)0);
+				else if (type == typeof(long))
+					Emitter.Emit(il, OpCodes.Ldc_I8, (long)0);
+				else
+					Emitter.Emit(il, OpCodes.Ldc_I4, 0);
+				Emitter.Emit(il, OpCodes.Stloc, v);
+				return v;
+			}
+			return null;
+		}
+
+		public static void PrepareDynamicMethod(DynamicMethod method)
+		{
+			var m_CreateDynMethod = typeof(DynamicMethod).GetMethod("CreateDynMethod", BindingFlags.NonPublic | BindingFlags.Instance);
+			m_CreateDynMethod.Invoke(method, new object[0]);
+		}
+	}
+}

--- a/ModLoader/Harmony/Tools/Extensions.cs
+++ b/ModLoader/Harmony/Tools/Extensions.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Harmony
+{
+	public static class GeneralExtensions
+	{
+		public static string Description(this Type[] parameters)
+		{
+			var types = parameters.Select(p => p == null ? "null" : p.FullName);
+			return "(" + types.Aggregate("", (s, x) => s.Length == 0 ? x : s + ", " + x) + ")";
+		}
+
+		public static Type[] Types(this ParameterInfo[] pinfo)
+		{
+			return pinfo.Select(pi => pi.ParameterType).ToArray();
+		}
+
+		public static T GetValueSafe<S, T>(this Dictionary<S, T> dictionary, S key)
+		{
+			T result;
+			if (dictionary.TryGetValue(key, out result))
+				return result;
+			return default(T);
+		}
+
+		public static T GetTypedValue<T>(this Dictionary<string, object> dictionary, string key)
+		{
+			object result;
+			if (dictionary.TryGetValue(key, out result))
+				if (result is T)
+					return (T)result;
+			return default(T);
+		}
+	}
+
+	public static class CollectionExtensions
+	{
+		public static IEnumerable<T> Do<T>(this IEnumerable<T> sequence, Action<T> action)
+		{
+			if (sequence == null) return null;
+			var enumerator = sequence.GetEnumerator();
+			while (enumerator.MoveNext()) action(enumerator.Current);
+			return sequence;
+		}
+
+		public static IEnumerable<T> DoIf<T>(this IEnumerable<T> sequence, Func<T, bool> condition, Action<T> action)
+		{
+			return sequence.Where(condition).Do(action);
+		}
+
+		public static IEnumerable<T> Add<T>(this IEnumerable<T> sequence, T item)
+		{
+			return (sequence ?? Enumerable.Empty<T>()).Concat(new[] { item });
+		}
+
+		public static T[] AddRangeToArray<T>(this T[] sequence, T[] items)
+		{
+			return (sequence ?? Enumerable.Empty<T>()).Concat(items).ToArray();
+		}
+
+		public static T[] AddToArray<T>(this T[] sequence, T item)
+		{
+			return Add(sequence, item).ToArray();
+		}
+	}
+}

--- a/ModLoader/Harmony/Tools/FileLog.cs
+++ b/ModLoader/Harmony/Tools/FileLog.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Harmony
+{
+	public static class FileLog
+	{
+		public static void Log(string str)
+		{
+			var path = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + Path.DirectorySeparatorChar + "harmony.log.txt";
+			using (StreamWriter writer = File.AppendText(path))
+			{
+				writer.WriteLine(str);
+			}
+		}
+
+		public static void Reset()
+		{
+			var path = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + Path.DirectorySeparatorChar + "harmony.log.txt";
+			File.Delete(path);
+		}
+
+		public static unsafe void LogBytes(long ptr, int len)
+		{
+			var p = (byte*)ptr;
+			string s = "";
+			for (int i = 1; i <= len; i++)
+			{
+				if (s == "") s = "#  ";
+				s = s + (*p).ToString("X2") + " ";
+				if (i > 1 || len == 1)
+				{
+					if (i % 8 == 0 || i == len)
+					{
+						Log(s);
+						s = "";
+					}
+					else if (i % 4 == 0)
+						s = s + " ";
+				}
+				p++;
+			}
+
+			byte[] arr = new byte[len];
+			Marshal.Copy((IntPtr)ptr, arr, 0, len);
+			var md5Hash = MD5.Create();
+			var hash = md5Hash.ComputeHash(arr);
+#pragma warning disable XS0001
+			var sBuilder = new StringBuilder();
+#pragma warning restore XS0001
+			for (int i = 0; i < hash.Length; i++)
+				sBuilder.Append(hash[i].ToString("X2"));
+			Log("HASH: " + sBuilder);
+		}
+	}
+}

--- a/ModLoader/Harmony/Tools/PatchTools.cs
+++ b/ModLoader/Harmony/Tools/PatchTools.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Harmony
+{
+	public static class PatchTools
+	{
+		// this holds all the objects we want to keep alive so they don't get garbage-collected
+		static Dictionary<object, object> objectReferences = new Dictionary<object, object>();
+		public static void RememberObject(object key, object value)
+		{
+			objectReferences[key] = value;
+		}
+
+		public static MethodInfo GetPatchMethod<T>(Type patchType, string name, Type[] parameters = null)
+		{
+			var method = patchType.GetMethods(AccessTools.all)
+				.FirstOrDefault(m => m.GetCustomAttributes(typeof(T), true).Count() > 0);
+			if (method == null)
+				method = AccessTools.Method(patchType, name, parameters);
+			return method;
+		}
+
+		public static void GetPatches(Type patchType, MethodBase original, out MethodInfo prefix, out MethodInfo postfix, out MethodInfo transpiler)
+		{
+			var type = original.DeclaringType;
+			var methodName = original.Name;
+
+			prefix = GetPatchMethod<HarmonyPrefix>(patchType, "Prefix");
+			postfix = GetPatchMethod<HarmonyPostfix>(patchType, "Postfix");
+			transpiler = GetPatchMethod<HarmonyTranspiler>(patchType, "Transpiler");
+		}
+	}
+}

--- a/ModLoader/Harmony/Tools/Traverse.cs
+++ b/ModLoader/Harmony/Tools/Traverse.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Harmony
+{
+	public class Traverse
+	{
+		static AccessCache Cache;
+
+		Type _type;
+		object _root;
+		MemberInfo _info;
+		MethodBase _method;
+		object[] _params;
+
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		static Traverse()
+		{
+			if (Cache == null)
+				Cache = new AccessCache();
+		}
+
+		public static Traverse Create(Type type)
+		{
+			return new Traverse(type);
+		}
+
+		public static Traverse Create<T>()
+		{
+			return Create(typeof(T));
+		}
+
+		public static Traverse Create(object root)
+		{
+			return new Traverse(root);
+		}
+
+		public static Traverse CreateWithType(string name)
+		{
+			return new Traverse(AccessTools.TypeByName(name));
+		}
+
+		Traverse()
+		{
+		}
+
+		public Traverse(Type type)
+		{
+			_type = type;
+		}
+
+		public Traverse(object root)
+		{
+			_root = root;
+			_type = root == null ? null : root.GetType();
+		}
+
+		Traverse(object root, MemberInfo info, object[] index)
+		{
+			_root = root;
+			_type = root == null ? null : root.GetType();
+			_info = info;
+			_params = index;
+		}
+
+		Traverse(object root, MethodInfo method, object[] parameter)
+		{
+			_root = root;
+			_type = method.ReturnType;
+			_method = method;
+			_params = parameter;
+		}
+
+		public object GetValue()
+		{
+			if (_info is FieldInfo)
+				return ((FieldInfo)_info).GetValue(_root);
+			if (_info is PropertyInfo)
+				return ((PropertyInfo)_info).GetValue(_root, AccessTools.all, null, _params, CultureInfo.CurrentCulture);
+			if (_method != null)
+				return _method.Invoke(_root, _params);
+			if (_root == null && _type != null) return _type;
+			return _root;
+		}
+
+		public object GetValue(params object[] arguments)
+		{
+			if (_method == null)
+				throw new Exception("cannot get method value without method");
+			return _method.Invoke(_root, arguments);
+		}
+
+		public object GetValue<T>(params object[] arguments)
+		{
+			if (_method == null)
+				throw new Exception("cannot get method value without method");
+			return (T)_method.Invoke(_root, arguments);
+		}
+
+		Traverse Resolve()
+		{
+			if (_root == null && _type != null) return this;
+			return new Traverse(GetValue());
+		}
+
+		public T GetValue<T>()
+		{
+			var value = GetValue();
+			if (value == null) return default(T);
+			return (T)value;
+		}
+
+		public Traverse SetValue(object value)
+		{
+			if (_info is FieldInfo)
+				((FieldInfo)_info).SetValue(_root, value, AccessTools.all, null, CultureInfo.CurrentCulture);
+			if (_info is PropertyInfo)
+				((PropertyInfo)_info).SetValue(_root, value, AccessTools.all, null, _params, CultureInfo.CurrentCulture);
+			if (_method != null)
+				throw new Exception("cannot set value of a method");
+			return this;
+		}
+
+		public Traverse Type(string name)
+		{
+			if (name == null) throw new Exception("name cannot be null");
+			if (_type == null) return new Traverse();
+			var type = AccessTools.Inner(_type, name);
+			if (type == null) return new Traverse();
+			return new Traverse(type);
+		}
+
+		public Traverse Field(string name)
+		{
+			if (name == null) throw new Exception("name cannot be null");
+			var resolved = Resolve();
+			if (resolved._type == null) return new Traverse();
+			var info = Cache.GetFieldInfo(resolved._type, name);
+			if (info == null) return new Traverse();
+			if (info.IsStatic == false && resolved._root == null) return new Traverse();
+			return new Traverse(resolved._root, info, null);
+		}
+
+		public Traverse Property(string name, object[] index = null)
+		{
+			if (name == null) throw new Exception("name cannot be null");
+			var resolved = Resolve();
+			if (resolved._root == null || resolved._type == null) return new Traverse();
+			var info = Cache.GetPropertyInfo(resolved._type, name);
+			if (info == null) return new Traverse();
+			return new Traverse(resolved._root, info, index);
+		}
+
+		public Traverse Method(string name, params object[] arguments)
+		{
+			if (name == null) throw new Exception("name cannot be null");
+			var resolved = Resolve();
+			if (resolved._type == null) return new Traverse();
+			var types = AccessTools.GetTypes(arguments);
+			_method = Cache.GetMethodInfo(resolved._type, name, types);
+			if (_method == null) return new Traverse();
+			return new Traverse(resolved._root, (MethodInfo)_method, arguments);
+		}
+
+		public Traverse Method(string name, Type[] paramTypes, object[] arguments = null)
+		{
+			if (name == null) throw new Exception("name cannot be null");
+			var resolved = Resolve();
+			if (resolved._type == null) return new Traverse();
+			_method = Cache.GetMethodInfo(resolved._type, name, paramTypes);
+			if (_method == null) return new Traverse();
+			return new Traverse(resolved._root, (MethodInfo)_method, arguments);
+		}
+
+		public static void IterateFields(object source, Action<Traverse> action)
+		{
+			var sourceTrv = Create(source);
+			AccessTools.GetFieldNames(source).ForEach(f => action(sourceTrv.Field(f)));
+		}
+
+		public static void IterateFields(object source, object target, Action<Traverse, Traverse> action)
+		{
+			var sourceTrv = Create(source);
+			var targetTrv = Create(target);
+			AccessTools.GetFieldNames(source).ForEach(f => action(sourceTrv.Field(f), targetTrv.Field(f)));
+		}
+
+		public static void IterateProperties(object source, Action<Traverse> action)
+		{
+			var sourceTrv = Create(source);
+			AccessTools.GetPropertyNames(source).ForEach(f => action(sourceTrv.Property(f)));
+		}
+
+		public static void IterateProperties(object source, object target, Action<Traverse, Traverse> action)
+		{
+			var sourceTrv = Create(source);
+			var targetTrv = Create(target);
+			AccessTools.GetPropertyNames(source).ForEach(f => action(sourceTrv.Property(f), targetTrv.Property(f)));
+		}
+
+		public override string ToString()
+		{
+			var value = _method != null ? _method : GetValue();
+			if (value == null) return null;
+			return value.ToString();
+		}
+	}
+}

--- a/ModLoader/Harmony/Transpilers.cs
+++ b/ModLoader/Harmony/Transpilers.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Harmony
+{
+	public static class Transpilers
+	{
+		public static IEnumerable<CodeInstruction> MethodReplacer(this IEnumerable<CodeInstruction> instructions, MethodBase from, MethodBase to)
+		{
+			foreach (var instruction in instructions)
+			{
+				if (instruction.operand == from)
+					instruction.operand = to;
+				yield return instruction;
+			}
+		}
+
+		public static IEnumerable<CodeInstruction> DebugLogger(this IEnumerable<CodeInstruction> instructions, string text)
+		{
+			yield return new CodeInstruction(OpCodes.Ldstr, text);
+			yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(FileLog), nameof(FileLog.Log)));
+			foreach (var instruction in instructions) yield return instruction;
+		}
+	}
+}

--- a/ModLoader/ModLoader.csproj
+++ b/ModLoader/ModLoader.csproj
@@ -24,6 +24,7 @@
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -112,6 +113,34 @@
     <Compile Include="ConfigurationEventArgs.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Game.cs" />
+    <Compile Include="Harmony\Attributes.cs" />
+    <Compile Include="Harmony\CodeInstruction.cs" />
+    <Compile Include="Harmony\CodeTranspiler.cs" />
+    <Compile Include="Harmony\Extras\DelegateTypeFactory.cs" />
+    <Compile Include="Harmony\Extras\FastAccess.cs" />
+    <Compile Include="Harmony\Extras\MethodInvoker.cs" />
+    <Compile Include="Harmony\HarmonyInstance.cs" />
+    <Compile Include="Harmony\HarmonyMethod.cs" />
+    <Compile Include="Harmony\HarmonySharedState.cs" />
+    <Compile Include="Harmony\ILCopying\ByteBuffer.cs" />
+    <Compile Include="Harmony\ILCopying\Emitter.cs" />
+    <Compile Include="Harmony\ILCopying\ILInstruction.cs" />
+    <Compile Include="Harmony\ILCopying\Memory.cs" />
+    <Compile Include="Harmony\ILCopying\MethodCopier.cs" />
+    <Compile Include="Harmony\ILCopying\MonoInternals.cs" />
+    <Compile Include="Harmony\MethodPatcher.cs" />
+    <Compile Include="Harmony\Patch.cs" />
+    <Compile Include="Harmony\PatchFunctions.cs" />
+    <Compile Include="Harmony\PatchProcessor.cs" />
+    <Compile Include="Harmony\Priority.cs" />
+    <Compile Include="Harmony\Tools\AccessCache.cs" />
+    <Compile Include="Harmony\Tools\AccessTools.cs" />
+    <Compile Include="Harmony\Tools\DynamicTools.cs" />
+    <Compile Include="Harmony\Tools\Extensions.cs" />
+    <Compile Include="Harmony\Tools\FileLog.cs" />
+    <Compile Include="Harmony\Tools\PatchTools.cs" />
+    <Compile Include="Harmony\Tools\Traverse.cs" />
+    <Compile Include="Harmony\Transpilers.cs" />
     <Compile Include="Internal\Activator.cs" />
     <Compile Include="Internal\InternalMod.cs" />
     <Compile Include="Internal\ModLoaderHudInputControl.cs" />
@@ -215,9 +244,10 @@
   <ItemGroup>
     <None Include="Resources\UI\thumb-vertical.png" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y $(TargetPath) %25BESIEGE_LOCATION%25Besiege_Data\Mods\SpaarModLoader.dll</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(TargetPath)" "%25BESIEGE_LOCATION%25Besiege_Data\Mods\SpaarModLoader.dll"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>

--- a/ModLoader/ModLoader.csproj
+++ b/ModLoader/ModLoader.csproj
@@ -36,6 +36,7 @@
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Build and Install|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -57,6 +58,7 @@
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseDeveloper|AnyCPU'">
     <OutputPath>bin\ReleaseDeveloper\</OutputPath>
@@ -68,6 +70,7 @@
     <CodeAnalysisRuleSet>ModLoader.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\SpaarModLoader.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ Check the README_enduser.md file for information about installing the mod loader
 License
 =======
 The mod loader is licensed under the MIT license.
-It is using the Mono.Cecil library, which is licensed under a similiar license.
-The full license text can be found in the LICENSE file.
+It is using the Mono.Cecil and Harmony libraries, which are licensed under a similiar license.
+The full license text for the mod loader and each library can be found in the LICENSE file.


### PR DESCRIPTION
Merges main source from [Harmony](https://github.com/pardeike/Harmony) into the modloader dll under the namespace `Harmony`. There doesn't appear to be any bugs in the tool's main purpose & feature set or as a result of the merge, and packaging it with the modloader will allow mods such as @lench4991's [ACM](https://github.com/lench4991/AdvancedControlsMod) to do more than what's currently possible.
Also in this PR is /unsafe being enabled (Harmony requires it), and the copy after building now works with paths that contain whitespace (eg. `C:\Program Files (x86)\Steam\steamapps\common\Besiege`).