### PR TITLE
Fixed version downloading from GitHub

### DIFF
--- a/ModLoader Installer/FormLoadingScreen.cs
+++ b/ModLoader Installer/FormLoadingScreen.cs
@@ -16,6 +16,7 @@ namespace spaar.ModLoader.Installer
 
     private void FormLoadingScreen_Load(object sender, EventArgs e)
     {
+      ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Ssl3;
       var client = new WebClient();
       client.DownloadStringCompleted += DownloadComplete;
       // GitHub does not return correct results if no user agent is set


### PR DESCRIPTION
GitHub [recently dropped support for TLS 1](https://githubengineering.com/crypto-deprecation-notice/) and it appears that the default TLS version of WebClient is TLS 1.1. This commit allows the installer to use TLS 1.2 or SSL instead of older versions.